### PR TITLE
[ATL-1453] Use explicit version for Structurizr Lite docker image

### DIFF
--- a/docs/architecture/Dockerfile
+++ b/docs/architecture/Dockerfile
@@ -1,3 +1,3 @@
-FROM structurizr/lite:latest
+FROM structurizr/lite:2793
 
 COPY ./structurizr /usr/local/structurizr


### PR DESCRIPTION
Use explicit version number for Structurizr Lite docker image

# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
Contributes ATL-1453

# Added features
<!-- Short list of new features/fixes added -->
- [x] Use explicit version number for Structurizr Lite docker image
# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually