### PR TITLE
refactor: remove wrongly added github conf folder

### DIFF
--- a/github_conf/branch_protection_rules.json
+++ b/github_conf/branch_protection_rules.json
@@ -1,4 +1,0 @@
-{
-    "message": "Not Found",
-    "documentation_url": "https://docs.github.com/rest"
-}


### PR DESCRIPTION
# Overview
Removes wrongly added `github_conf` directory

# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually