### PR TITLE
ci: add fast-forward PR merge workflow

### DIFF
--- a/.github/workflows/ff-merge.yml
+++ b/.github/workflows/ff-merge.yml
@@ -1,0 +1,33 @@
+name: Fast-forward merge
+
+# This workflow helps to work around the bug in the **Rebase and Merge** pull requests strategy.
+# The bug leads to unsigned commits and prevents using the strategy
+# without IOG policy violation (all commits must be signed by PGP signature).
+#
+# This workflow helps to merge multiple commits from PR to main branch of the repository
+# without loosing of PGP signature.
+#
+# Related GitHub discussions: 
+# https://github.com/community/community/discussions/10410
+# https://github.com/orgs/community/discussions/5524
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  fast_forward_job:
+    name: Fast Forward Merge
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request != '' &&
+      contains(github.event.comment.body, '/fast-forward')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Fast Forward Merge
+        uses: endre-spotlab/fast-forward-js-action@2.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          success_message: 'Success! Fast forwarded ***target_base*** to ***source_head***! ```git checkout target_base && git merge source_head --ff-only``` '
+          failure_message: 'Failed! Cannot do fast forward!'


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
Related to ATL-1899

This workflow helps to work around the bug in the **Rebase and Merge** pull requests strategy.
The bug leads to unsigned commits and prevents using the strategy without IOG policy violation (all commits must be signed by PGP signature).

This workflow helps to merge multiple commits from PR to the `main` branch of the repository without loosing of PGP signature.

Related GitHub discussions: 
* https://github.com/community/community/discussions/10410
* https://github.com/orgs/community/discussions/5524

# How to use

By adding `/fast-forward` comment in the PR, it will automatically be rebased and fast-forward merged to the main branch of the repository.

# Added features
<!-- Short list of new features/fixes added -->
- [x] Adds fast-forward PR merge workflow
# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually