### PR TITLE
fix(prism-agent): reuse db connection for background job

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Modules.scala
@@ -77,17 +77,17 @@ object Modules {
   val didCommServiceEndpoint: Task[Nothing] = {
     val app: HttpApp[Any, Nothing] =
       Http.collect[Request] { case Method.POST -> !! / "did-comm-v2" =>
-        // TODO add DIDComm messages parsing logic here! 
+        // TODO add DIDComm messages parsing logic here!
         Response.text("Hello World!").setStatus(Status.Accepted)
       }
     Server.start(8090, app)
   }
 
-  val didCommExchangesJob: Task[Unit] = {
-    val effect = BackgroundJobs.didCommExchanges
+  val didCommExchangesJob: Task[Unit] =
+    BackgroundJobs.didCommExchanges
+      .repeat(Schedule.spaced(10.seconds))
+      .unit
       .provideLayer(AppModule.credentialServiceLayer)
-    (effect repeat Schedule.spaced(10.seconds)).unit
-  }
 
 }
 
@@ -191,7 +191,6 @@ object HttpModule {
   }
 
   val layers =
-   
     didApiLayer ++ didOperationsApiLayer ++ didAuthenticationApiLayer ++ didRegistrarApiLayer ++ issueCredentialsApiLayer ++ issueCredentialsProtocolApiLayer
 }
 

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/http/HttpRoutes.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/http/HttpRoutes.scala
@@ -16,7 +16,8 @@ import akka.http.scaladsl.server.Route
 object HttpRoutes {
 
   def routes: URIO[
-    DIDApi & DIDOperationsApi & DIDAuthenticationApi & DIDRegistrarApi & IssueCredentialsApi & IssueCredentialsProtocolApi,
+    DIDApi & DIDOperationsApi & DIDAuthenticationApi & DIDRegistrarApi & IssueCredentialsApi &
+      IssueCredentialsProtocolApi,
     Route
   ] =
     for {


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
Fixes ATL-2005 ATL-1333. Tweak DBLayer injection so that a repeating effect has DB connection shared.

# Added features
<!-- Short list of new features/fixes added -->
- [x] share db connection for all background effect invocation
- [x] run code formatter on `prism-agent`
# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually