### PR TITLE
chore(iris): rename docker image from server to service

### DIFF
--- a/iris/service/build.sbt
+++ b/iris/service/build.sbt
@@ -61,7 +61,7 @@ lazy val sql = commonProject(project)
 lazy val server = commonProject(project)
   .in(file("server"))
   .settings(
-    name := "iris-server",
+    name := "iris-service",
     libraryDependencies ++= serverDependencies,
     Docker / maintainer := "atala-coredid@iohk.io",
     Docker / dockerUsername := Some("input-output-hk"),


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Simple rename of the Docker image for iris for consistency in auto-deployment

# Added features
<!-- Short list of new features/fixes added -->
- [x] `iris-server` to `iris-service` rename
# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually