### PR TITLE
chore(pollux): upgrade shared lib version

### DIFF
--- a/pollux/lib/project/Dependencies.scala
+++ b/pollux/lib/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val zioCatsInterop = "3.3.0"
     val prismSdk = "v1.3.3-snapshot-1657194253-992dd96"
     val iris = "0.1.0"
-    val shared = "0.1.0"
+    val shared = "0.2.0"
     val mercury = "0.6.0"
     val flyway = "9.7.0"
   }


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
Relates to ATL-2190. Due to dependency conflict when compiling `prism-agent` on https://github.com/input-output-hk/atala-prism-building-blocks/pull/141, the version of `shared` should be upgraded on pollux as well.

# Added features
<!-- Short list of new features/fixes added -->
- [ ]
# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [ ] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [ ] Any changes not covered by tests have been tested manually