### PR TITLE
feat(prism-agent): make didcomm service url configurable

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
@@ -42,6 +42,12 @@ object Main extends ZIOAppDefault {
       }
       _ <- ZIO.logInfo(s"REST Service port => $restServicePort")
 
+      didCommServiceUrl <- System.env("DIDCOMM_SERVICE_URL").map {
+        case Some(s) => s
+        case _       => "http://localhost"
+      }
+      _ <- ZIO.logInfo(s"DIDComm Service URL => $didCommServiceUrl")
+
       didCommServicePort <- System.env("DIDCOMM_SERVICE_PORT").map {
         case Some(s) if s.toIntOption.isDefined => s.toInt
         case _                                  => 8090
@@ -60,7 +66,7 @@ object Main extends ZIOAppDefault {
         .provide(RepoModule.connectDbConfigLayer >>> ConnectMigrations.layer)
 
       agentDID <- for {
-        peer <- ZIO.succeed(PeerDID.makePeerDid(serviceEndpoint = Some(s"http://localhost:$didCommServicePort")))
+        peer <- ZIO.succeed(PeerDID.makePeerDid(serviceEndpoint = Some(s"$didCommServiceUrl:$didCommServicePort")))
         _ <- ZIO.logInfo(s"New DID: ${peer.did}") *>
           ZIO.logInfo(s"JWK for KeyAgreement: ${peer.jwkForKeyAgreement.toJSONString}") *>
           ZIO.logInfo(s"JWK for KeyAuthentication: ${peer.jwkForKeyAuthentication.toJSONString}")


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

allows to set up didcomm communications in other networks

for example, between docker containers in proprietary network

# Added features
<!-- Short list of new features/fixes added -->
- [x] Make didcomm URL endpoint configurable from environment variable
# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually