### PR TITLE
ci(release): prevent running multiple releases in parallel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+concurrency:
+  group: release
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Multiple release jobs in parallel can cause git conflicts while pushing tags.

Run them consequently, one by one.

# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually