### PR TITLE
release: use publishCmd instead of prepareCmd for packages release

### DIFF
--- a/castor/lib/package.json
+++ b/castor/lib/package.json
@@ -32,7 +32,7 @@
         [
           "@semantic-release/exec",
           {
-            "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+            "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
           }
         ],
         [

--- a/connect/lib/package.json
+++ b/connect/lib/package.json
@@ -32,7 +32,7 @@
         [
           "@semantic-release/exec",
           {
-            "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+            "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
           }
         ],
         [

--- a/iris/client/scala-client/package.json
+++ b/iris/client/scala-client/package.json
@@ -32,7 +32,7 @@
         [
           "@semantic-release/exec",
           {
-            "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+            "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
           }
         ],
         [

--- a/iris/service/package.json
+++ b/iris/service/package.json
@@ -32,7 +32,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+          "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
         }
       ],
       [

--- a/mercury/mercury-library/package.json
+++ b/mercury/mercury-library/package.json
@@ -30,6 +30,12 @@
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",
         [
+          "@semantic-release/exec",
+          {
+            "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+          }
+        ],
+        [
           "@semantic-release/changelog",
           {
             "changelogFile": "CHANGELOG.md"

--- a/mercury/mercury-mediator/package.json
+++ b/mercury/mercury-mediator/package.json
@@ -32,7 +32,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+          "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
         }
       ],
       [

--- a/pollux/lib/package.json
+++ b/pollux/lib/package.json
@@ -32,7 +32,7 @@
         [
           "@semantic-release/exec",
           {
-            "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+            "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
           }
         ],
         [

--- a/prism-agent/service/package.json
+++ b/prism-agent/service/package.json
@@ -32,7 +32,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+          "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
         }
       ],
       [

--- a/prism-node/client/scala-client/package.json
+++ b/prism-node/client/scala-client/package.json
@@ -32,7 +32,7 @@
         [
           "@semantic-release/exec",
           {
-            "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+            "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
           }
         ],
         [

--- a/shared/package.json
+++ b/shared/package.json
@@ -32,7 +32,7 @@
         [
           "@semantic-release/exec",
           {
-            "prepareCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
+            "publishCmd": "sbt \"release release-version ${nextRelease.version} next-version ${nextRelease.version}-SNAPSHOT with-defaults\""
           }
         ],
         [


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Use `publishCmd` instead of `prepareCmd` to simplify debugging of failed jobs for released packages and release them only after git correctly works without conflicts

# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually