### PR TITLE
infra: make prism-agent wait for db

### DIFF
--- a/infrastructure/shared/docker-compose.yml
+++ b/infrastructure/shared/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  
+
   pgadmin:
     image: dpage/pgadmin4
     environment:
@@ -73,7 +73,8 @@ services:
       CONNECT_DB_PASSWORD: postgres
       DIDCOMM_SERVICE_URL: http://host.docker.internal:${PORT}/didcomm/
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://prism-agent:8080/connections" ]
       interval: 30s


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
When running `./infrastructure/local/run.sh`, there can be a race condition where `prism-agent` is ready before DB is healthy especially after removing docker volume and DB takes slightly longer to initialize. This PR makes the `prism-agent` wait for DB to be healthy in local deployment.

# Added features
<!-- Short list of new features/fixes added -->
- [x] make `prism-agent` wait for healthy DB in local deployment
# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [ ] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [ ] Any changes not covered by tests have been tested manually