### PR TITLE
fix(prism-agent): switch datetime format to offsetdatetime.ATL-2723

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/pollux/schema/model/VerifiableCredentialSchema.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/pollux/schema/model/VerifiableCredentialSchema.scala
@@ -1,12 +1,12 @@
 package io.iohk.atala.pollux.schema.model
 
-import sttp.model.Uri._
 import sttp.model.Uri
+import sttp.model.Uri.*
 import sttp.tapir.Schema
 import sttp.tapir.Schema.annotations.{description, encodedName}
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder}
 
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZoneOffset}
 import java.util.UUID
 
 case class VerifiableCredentialSchema(
@@ -17,7 +17,7 @@ case class VerifiableCredentialSchema(
     description: Option[String],
     attributes: List[String],
     author: String,
-    authored: ZonedDateTime,
+    authored: OffsetDateTime,
     proof: Option[Proof],
     kind: String = "VerifiableCredentialSchema",
     self: String = ""
@@ -36,7 +36,7 @@ object VerifiableCredentialSchema {
       description = in.description,
       attributes = in.attributes,
       author = "Prism Agent",
-      authored = in.authored.getOrElse(ZonedDateTime.now()),
+      authored = in.authored.getOrElse(OffsetDateTime.now(ZoneOffset.UTC)),
       proof = None
     )
 
@@ -64,7 +64,7 @@ case class VerifiableCredentialSchemaInput(
     version: String,
     description: Option[String],
     attributes: List[String],
-    authored: Option[ZonedDateTime],
+    authored: Option[OffsetDateTime],
     tags: List[String]
 )
 

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/pollux/schema/model/VerificationPolicy.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/pollux/schema/model/VerificationPolicy.scala
@@ -5,7 +5,7 @@ import sttp.tapir.Schema
 import sttp.tapir.Schema.annotations.{description, encodedName}
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder}
 
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZoneOffset}
 import java.util.UUID
 
 case class VerificationPolicy(
@@ -16,8 +16,8 @@ case class VerificationPolicy(
     attributes: List[String],
     issuerDIDs: List[String],
     credentialTypes: List[String],
-    createdAt: ZonedDateTime,
-    updatedAt: ZonedDateTime
+    createdAt: OffsetDateTime,
+    updatedAt: OffsetDateTime
 ) {
   def update(in: VerificationPolicyInput): VerificationPolicy = {
     copy(
@@ -25,7 +25,7 @@ case class VerificationPolicy(
       attributes = in.attributes,
       issuerDIDs = in.issuerDIDs,
       credentialTypes = in.credentialTypes,
-      updatedAt = ZonedDateTime.now()
+      updatedAt = OffsetDateTime.now(ZoneOffset.UTC)
     )
   }
 
@@ -46,8 +46,8 @@ object VerificationPolicy {
       attributes = in.attributes,
       issuerDIDs = in.issuerDIDs,
       credentialTypes = in.credentialTypes,
-      createdAt = in.createdAt.getOrElse(ZonedDateTime.now()),
-      updatedAt = in.updatedAt.getOrElse(ZonedDateTime.now())
+      createdAt = in.createdAt.getOrElse(OffsetDateTime.now(ZoneOffset.UTC)),
+      updatedAt = in.updatedAt.getOrElse(OffsetDateTime.now(ZoneOffset.UTC))
     )
 
   given encoder: zio.json.JsonEncoder[VerificationPolicy] = DeriveJsonEncoder.gen[VerificationPolicy]
@@ -95,8 +95,8 @@ case class VerificationPolicyInput(
     attributes: List[String],
     issuerDIDs: List[String],
     credentialTypes: List[String],
-    createdAt: Option[ZonedDateTime] = None,
-    updatedAt: Option[ZonedDateTime] = None
+    createdAt: Option[OffsetDateTime] = None,
+    updatedAt: Option[OffsetDateTime] = None
 )
 
 object VerificationPolicyInput {

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/pollux/SchemaRegistryEndpointsSpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/pollux/SchemaRegistryEndpointsSpec.scala
@@ -3,34 +3,32 @@ package io.iohk.atala.pollux
 import io.iohk.atala.agent.server.http.ZHttp4sBlazeServer
 import io.iohk.atala.api.http.{BadRequest, NotFound}
 import io.iohk.atala.pollux.SchemaRegistryEndpointsSpec.schemaReqistrySchemasUri
+import io.iohk.atala.pollux.schema.*
 import io.iohk.atala.pollux.schema.model.{
   VerifiableCredentialSchema,
   VerifiableCredentialSchemaInput,
   VerifiableCredentialSchemaPage
 }
-import io.iohk.atala.pollux.schema.*
 import io.iohk.atala.pollux.service.{SchemaRegistryService, SchemaRegistryServiceInMemory}
 import sttp.client3.testing.SttpBackendStub
 import sttp.client3.ziojson.*
 import sttp.client3.{DeserializationException, ResponseException, SttpBackend, UriContext, basicRequest}
+import sttp.model.{StatusCode, Uri}
 import sttp.monad.MonadError
 import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.interceptor.RequestResult.Response
 import sttp.tapir.server.stub.TapirStubInterpreter
 import sttp.tapir.ztapir.RIOMonadError
-import zio.ZIO
-import zio.test.*
-import zio.test.Assertion.*
-import sttp.model.{StatusCode, Uri}
 import zio.json.{DecoderOps, EncoderOps, JsonDecoder}
 import zio.stream.ZSink
 import zio.stream.ZSink.*
 import zio.stream.ZStream.unfold
+import zio.test.*
 import zio.test.Assertion.*
 import zio.test.Gen.*
-import zio.{Random, ZLayer, *}
+import zio.{Random, ZIO, ZLayer, *}
 
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZoneOffset}
 import java.util.UUID
 
 object Generators {
@@ -40,7 +38,7 @@ object Generators {
   val schemaDescription = Gen.alphaNumericStringBounded(5, 30)
   val schemaAttribute = Gen.alphaNumericStringBounded(3, 9)
   val schemaAttributes = Gen.setOfBounded(1, 4)(schemaAttribute).map(_.toList)
-  val schemaAuthored = Gen.zonedDateTime(min = ZonedDateTime.now().minusMonths(6), max = ZonedDateTime.now())
+  val schemaAuthored = Gen.offsetDateTime(min = OffsetDateTime.now().minusMonths(6), max = OffsetDateTime.now())
   val schemaTag: Gen[Any, String] = Gen.alphaNumericStringBounded(3, 5)
   val schemaTags: Gen[Any, List[String]] = Gen.setOfBounded(0, 3)(schemaTag).map(_.toList)
 
@@ -78,7 +76,7 @@ object SchemaRegistryEndpointsSpec extends ZIOSpecDefault:
     version = "1.0",
     description = Option("schema description"),
     attributes = List("first_name", "dob"),
-    authored = Option(ZonedDateTime.now()),
+    authored = Option(OffsetDateTime.now(ZoneOffset.UTC)),
     tags = List("test")
   )
 

--- a/prism-agent/service/server/src/test/scala/io/iohk/atala/pollux/VerificationPolicyEndpointsSpec.scala
+++ b/prism-agent/service/server/src/test/scala/io/iohk/atala/pollux/VerificationPolicyEndpointsSpec.scala
@@ -1,33 +1,29 @@
 package io.iohk.atala.pollux
 
+import io.iohk.atala.api.http.{BadRequest, NotFound}
 import io.iohk.atala.pollux.schema.VerificationPolicyServerEndpoints
 import io.iohk.atala.pollux.schema.model.{VerificationPolicy, VerificationPolicyInput, VerificationPolicyPage}
 import io.iohk.atala.pollux.service.{VerificationPolicyService, VerificationPolicyServiceInMemory}
-import sttp.client3.DeserializationException
 import sttp.client3.Response.ExampleGet.uri
-import io.iohk.atala.api.http.{BadRequest, NotFound}
-import zio.test.ZIOSpecDefault
 import sttp.client3.testing.SttpBackendStub
 import sttp.client3.ziojson.*
 import sttp.client3.{DeserializationException, ResponseException, SttpBackend, UriContext, basicRequest}
+import sttp.model.{StatusCode, Uri}
 import sttp.monad.MonadError
 import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.interceptor.RequestResult.Response
 import sttp.tapir.server.stub.TapirStubInterpreter
 import sttp.tapir.ztapir.RIOMonadError
-import zio.ZIO
-import zio.test.*
-import zio.test.Assertion.*
-import sttp.model.{StatusCode, Uri}
 import zio.json.{DecoderOps, EncoderOps, JsonDecoder}
 import zio.stream.ZSink
 import zio.stream.ZSink.*
 import zio.stream.ZStream.unfold
+import zio.test.*
 import zio.test.Assertion.*
 import zio.test.Gen.*
-import zio.{Random, ZLayer, *}
+import zio.{Random, ZIO, ZLayer, *}
 
-import java.time.ZonedDateTime
+import java.time.{OffsetDateTime, ZoneOffset, ZonedDateTime}
 import java.util.UUID
 
 object VerificationPolicyEndpointsSpec extends ZIOSpecDefault:
@@ -45,8 +41,8 @@ object VerificationPolicyEndpointsSpec extends ZIOSpecDefault:
     attributes = List("first_name", "dob"),
     issuerDIDs = List("did:prism:abc", "did:prism:xyz"),
     credentialTypes = List("DrivingLicence", "ID"),
-    createdAt = Some(ZonedDateTime.now()),
-    updatedAt = Some(ZonedDateTime.now())
+    createdAt = Some(OffsetDateTime.now(ZoneOffset.UTC)),
+    updatedAt = Some(OffsetDateTime.now(ZoneOffset.UTC))
   )
 
   private val verificationPoliciesUri = uri"http://test.com/verification/policies"


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
Fixes ATL-2723

# Added features
<!-- Short list of new features/fixes added -->
- [x] Adjust the format of DateTime fields to a offset ISO format. For instance: 2022-12-13T10:00:22.375229Z
# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually