### PR TITLE
feat(pollux): [ATL-2733] Allow for dates in seconds for exp, iss and iat

### DIFF
--- a/pollux/lib/vc-jwt/src/main/scala/io/iohk/atala/pollux/vc/jwt/InstantDecoderEncoder.scala
+++ b/pollux/lib/vc-jwt/src/main/scala/io/iohk/atala/pollux/vc/jwt/InstantDecoderEncoder.scala
@@ -1,0 +1,13 @@
+package io.iohk.atala.pollux.vc.jwt
+
+import io.circe.{Decoder, Encoder, HCursor}
+
+import java.time.Instant
+
+object InstantDecoderEncoder {
+  implicit val instantToEpochSecondsEncoder: Encoder[Instant] =
+    (instant: Instant) => Encoder.encodeLong(instant.getEpochSecond)
+
+  implicit val epochSecondsToInstantDecoder: Decoder[Instant] =
+    (c: HCursor) => Decoder.decodeLong.map(s => Instant.ofEpochSecond(s)).apply(c)
+}

--- a/pollux/lib/vc-jwt/src/main/scala/io/iohk/atala/pollux/vc/jwt/JWTVerification.scala
+++ b/pollux/lib/vc-jwt/src/main/scala/io/iohk/atala/pollux/vc/jwt/JWTVerification.scala
@@ -69,8 +69,8 @@ object JWTVerification {
   }
 
   def validateEncodedJwt(jwt: JWT, publicKey: PublicKey): Validation[String, Unit] =
-    if JwtCirce.isValid(jwt.value, publicKey) then Validation.unit
-    else Validation.fail(s"Jwt[$jwt] not singed by $publicKey")
+    if JwtCirce.isValid(jwt.value, publicKey, JwtOptions(expiration = false, notBefore = false)) then Validation.unit
+    else Validation.fail(s"Jwt[$jwt] not signed by $publicKey")
 
   def validateEncodedJwt(jwt: JWT, verificationMethods: IndexedSeq[VerificationMethod]): Validation[String, Unit] = {
     verificationMethods


### PR DESCRIPTION
# Overview
https://input-output.atlassian.net/browse/ATL-2733

Decode/Encode from/to EpochSeconds to/from instant instead of date string.