### PR TITLE
feat(pollux): use dedicated pairwise PeerDIDs

### DIFF
--- a/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/ConnectionService.scala
+++ b/connect/lib/core/src/main/scala/io/iohk/atala/connect/core/service/ConnectionService.scala
@@ -11,11 +11,11 @@ import io.iohk.atala.mercury.protocol.connection.ConnectionResponse
 
 trait ConnectionService {
 
-  def createConnectionInvitation(label: Option[String]): IO[ConnectionServiceError, ConnectionRecord]
+  def createConnectionInvitation(label: Option[String], pairwiseDID: DidId): IO[ConnectionServiceError, ConnectionRecord]
 
   def receiveConnectionInvitation(invitation: String): IO[ConnectionServiceError, ConnectionRecord]
 
-  def acceptConnectionInvitation(recordId: UUID): IO[ConnectionServiceError, Option[ConnectionRecord]]
+  def acceptConnectionInvitation(recordId: UUID, pairwiseDid: DidId): IO[ConnectionServiceError, Option[ConnectionRecord]]
 
   def markConnectionRequestSent(recordId: UUID): IO[ConnectionServiceError, Option[ConnectionRecord]]
 


### PR DESCRIPTION
Use dedicated pairwise DIDs during protocol execution instead of the same one coming from the global DIDComm agent.

# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
Fixes ATL-xxxx

# Added features
<!-- Short list of new features/fixes added -->
- [x] Use pairwise DIDs in connect and issue
# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually