### PR TITLE
feat(prism-agent): remove connection deletion enpoint from OAS spec

### DIFF
--- a/prism-agent/service/api/http/prism-agent-openapi-spec.yaml
+++ b/prism-agent/service/api/http/prism-agent-openapi-spec.yaml
@@ -926,18 +926,6 @@ paths:
             application/json:
               schema:
                 $ref: "./connect/schemas.yaml#/components/schemas/ErrorResponse"
-    delete:
-      tags: ["Connections Management"]
-      parameters:
-        - $ref: "./connect/schemas.yaml#/components/parameters/connectionId"
-      operationId: deleteConnection
-      summary: Deletes existing connection record.
-      description: Just deletes connection state in the Agent, it does not include notifing other party that connection is deleted. We should consider this feature for the future. If additional action is attempted over deleted connection, it should thow error (no matter which side deleted connection).
-      responses:
-        "200":
-          description: Successful delete
-        "404":
-          description: Connection state record not found for given `connectionId`
 
   /connection-invitations:
     post:

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/http/service/ConnectionsManagementApiServiceImpl.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/http/service/ConnectionsManagementApiServiceImpl.scala
@@ -110,7 +110,6 @@ class ConnectionsManagementApiServiceImpl(
     }
   }
 
-  override def deleteConnection(connectionId: String): Route = ???
 }
 
 object ConnectionsManagementApiServiceImpl {


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Removes the DELETE /connections/{id} endpoint from the `Connect` OAS specification.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
