### PR TITLE
tests: temporary disable present-proof until protocol fixed

### DIFF
--- a/tests/e2e-tests/src/test/resources/features/present_proof/present_proof.feature
+++ b/tests/e2e-tests/src/test/resources/features/present_proof/present_proof.feature
@@ -1,6 +1,6 @@
-#@RFC0037
-#Feature: Present Proof Protocol
-#
+@RFC0037
+Feature: Present Proof Protocol
+
 #  @AIP20
 #  Scenario: Holder presents credential proof to verifier
 #    Given Faber and Bob have an existing connection


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Temporary disables present-proof tests to stabilize e2e test runs.

Will be re-enabled and enhanced for v2.0 when the present-proof protocol changes.

## Checklist

### My PR contains...
* [x] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [x] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
