### PR TITLE
feat(pollux): disallow VP DID to be different from VC subject

### DIFF
--- a/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/model/IssueCredentialRecord.scala
+++ b/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/model/IssueCredentialRecord.scala
@@ -31,7 +31,8 @@ final case class IssueCredentialRecord(
 )
 final case class ValidIssuedCredentialRecord(
     id: UUID,
-    issuedCredentialRaw: Option[String]
+    issuedCredentialRaw: Option[String],
+    subjectId: String
 )
 
 object IssueCredentialRecord {

--- a/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/model/error/PresentationError.scala
+++ b/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/model/error/PresentationError.scala
@@ -13,4 +13,5 @@ object PresentationError {
   final case class IssuedCredentialNotFoundError(cause: Throwable) extends PresentationError
   final case class PresentationDecodingError(cause: Throwable) extends PresentationError
   final case class PresentationNotFoundError(cause: Throwable) extends PresentationError
+  final case class HolderBindingError(msg: String) extends PresentationError
 }

--- a/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/repository/CredentialRepositoryInMemory.scala
+++ b/pollux/lib/core/src/main/scala/io/iohk/atala/pollux/core/repository/CredentialRepositoryInMemory.scala
@@ -110,7 +110,7 @@ class CredentialRepositoryInMemory(storeRef: Ref[Map[UUID, IssueCredentialRecord
       store <- storeRef.get
     } yield store.values
       .filter(rec => recordId.contains(rec.id) && rec.issuedCredentialRaw.isDefined)
-      .map(rec => ValidIssuedCredentialRecord(rec.id, rec.issuedCredentialRaw))
+      .map(rec => ValidIssuedCredentialRecord(rec.id, rec.issuedCredentialRaw, rec.subjectId))
       .toSeq
   }
 

--- a/pollux/lib/core/src/test/scala/io/iohk/atala/pollux/core/repository/CredentialRepositorySpecSuite.scala
+++ b/pollux/lib/core/src/test/scala/io/iohk/atala/pollux/core/repository/CredentialRepositorySpecSuite.scala
@@ -223,7 +223,9 @@ object CredentialRepositorySpecSuite {
         records <- repo.getValidIssuedCredentials(Seq(aRecord.id, bRecord.id))
       } yield {
         assertTrue(records.size == 1) &&
-        assertTrue(records.contains(ValidIssuedCredentialRecord(aRecord.id, Some("RAW_CREDENTIAL_DATA"))))
+        assertTrue(
+          records.contains(ValidIssuedCredentialRecord(aRecord.id, Some("RAW_CREDENTIAL_DATA"), aRecord.subjectId))
+        )
       }
     },
     test("updateCredentialRecordProtocolState updates the record") {

--- a/pollux/lib/sql-doobie/src/main/scala/io/iohk/atala/pollux/sql/repository/JdbcCredentialRepository.scala
+++ b/pollux/lib/sql-doobie/src/main/scala/io/iohk/atala/pollux/sql/repository/JdbcCredentialRepository.scala
@@ -363,7 +363,8 @@ class JdbcCredentialRepository(xa: Transactor[Task]) extends CredentialRepositor
     val cxnIO = sql"""
         | SELECT
         |   id,
-        |   issued_credential_raw
+        |   issued_credential_raw,
+        |   subject_id
         | FROM public.issue_credential_records
         | WHERE
         |   issued_credential_raw IS NOT NULL


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

ATL-3244. This PR disallows the VP DID to be different from the VCs when the holder accepts the proof request. This check ensures that the `prism-agent` choose the correct DID to use in VP as it will no longer create a new Prism DID for every presentation.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
