### PR TITLE
fix(castor): use URI that is compliant to RFC3986

### DIFF
--- a/castor/lib/core/src/main/scala/io/iohk/atala/castor/core/model/ProtoModelHelper.scala
+++ b/castor/lib/core/src/main/scala/io/iohk/atala/castor/core/model/ProtoModelHelper.scala
@@ -1,6 +1,5 @@
 package io.iohk.atala.castor.core.model
 
-import java.net.URI
 import java.time.Instant
 import com.google.protobuf.ByteString
 import io.iohk.atala.castor.core.model.did.{
@@ -30,6 +29,7 @@ import io.iohk.atala.shared.models.HexStrings.*
 import io.iohk.atala.shared.models.Base64UrlStrings.*
 import io.iohk.atala.shared.utils.Traverse.*
 import io.iohk.atala.prism.protos.{common_models, node_api, node_models}
+import io.lemonlabs.uri.Uri
 import zio.*
 
 import scala.util.Try
@@ -239,7 +239,7 @@ private[castor] trait ProtoModelHelper {
     def toDomain: Either[String, Service] = {
       for {
         uris <- service.serviceEndpoint.traverse(s =>
-          Try(URI.create(s)).toEither.left.map(_ => s"unable to parse serviceEndpoint $s as URI")
+          Uri.parseTry(s).toEither.left.map(_ => s"unable to parse serviceEndpoint $s as URI")
         )
         serviceType <- ServiceType
           .parseString(service.`type`)

--- a/castor/lib/core/src/main/scala/io/iohk/atala/castor/core/model/did/PrismDIDOperation.scala
+++ b/castor/lib/core/src/main/scala/io/iohk/atala/castor/core/model/did/PrismDIDOperation.scala
@@ -7,7 +7,7 @@ import scala.collection.compat.immutable.ArraySeq
 import io.iohk.atala.prism.protos.node_models
 import io.iohk.atala.shared.models.HexStrings.HexString
 
-import java.net.URI
+import io.lemonlabs.uri.Uri
 
 sealed trait PrismDIDOperation {
   def did: CanonicalPrismDID
@@ -70,6 +70,6 @@ object UpdateDIDAction {
   final case class RemoveKey(id: String) extends UpdateDIDAction
   final case class AddService(service: Service) extends UpdateDIDAction
   final case class RemoveService(id: String) extends UpdateDIDAction
-  final case class UpdateService(id: String, `type`: Option[ServiceType] = None, endpoints: Seq[URI] = Nil)
+  final case class UpdateService(id: String, `type`: Option[ServiceType] = None, endpoints: Seq[Uri] = Nil)
       extends UpdateDIDAction
 }

--- a/castor/lib/core/src/main/scala/io/iohk/atala/castor/core/model/did/Service.scala
+++ b/castor/lib/core/src/main/scala/io/iohk/atala/castor/core/model/did/Service.scala
@@ -1,9 +1,19 @@
 package io.iohk.atala.castor.core.model.did
 
-import java.net.URI
+import io.iohk.atala.castor.core.util.UriUtils
+import io.lemonlabs.uri.Uri
 
 final case class Service(
     id: String,
     `type`: ServiceType,
-    serviceEndpoint: Seq[URI]
-)
+    serviceEndpoint: Seq[Uri]
+) {
+  def normalizeServiceEndpoint(): Service = {
+    val normalizedUris = serviceEndpoint.flatMap { uri =>
+      UriUtils.normalizeUri(uri.toString).map { normalizedUri =>
+        Uri.parse(normalizedUri)
+      }
+    }
+    this.copy(serviceEndpoint = normalizedUris)
+  }
+}

--- a/castor/lib/core/src/main/scala/io/iohk/atala/castor/core/util/UriUtils.scala
+++ b/castor/lib/core/src/main/scala/io/iohk/atala/castor/core/util/UriUtils.scala
@@ -1,0 +1,124 @@
+package io.iohk.atala.castor.core.util
+
+import io.lemonlabs.uri.{Uri, Url, Urn, QueryString}
+import io.lemonlabs.uri.config.UriConfig
+import io.lemonlabs.uri.encoding.PercentEncoder
+import io.lemonlabs.uri.decoding.UriDecodeException
+
+// TODO: unify with the logic used in Node
+// https://github.com/input-output-hk/atala-prism/blob/ba7b3e3ef307f6bd06734af2bf8fed9b119ee98e/prism-backend/common/src/main/scala/io/iohk/atala/prism/utils/UriUtils.scala
+object UriUtils {
+
+  /** Normalized URI according to <a
+    * href="https://www.rfc-editor.org/rfc/rfc3986#section-6">RFC&nbsp;3986,&nbsp;section-6</a>
+    *
+    * @param uri
+    * @return
+    *   [[Some]](uri) - normalized uri, if it is a valid uri string, or [[None]]
+    */
+  def normalizeUri(uriStr: String): Option[String] = {
+
+    /*
+     * List of normalizations performed:
+     *   percent encoding normalization
+     *     decode unreserved characters
+     *   case normalization
+     *     scheme and host to lowercase
+     *     all percent encoded triplets use uppercase hexadecimal chars
+     *   path segment normalization
+     *     remove "." and ".." segments from path
+     *     remove duplicate forward slashes (//) from path
+     *   scheme specific normalization (http, https) since it is likely to be often used type of URL
+     *     remove default port
+     *     sort query parameters by key alphabetically
+     *     remove duplicates (by name/key)
+     *     encode special characters that are disallowed in path and query
+     *     decode the ones that are allowed if encoded
+     *
+     * for URN:
+     *   convert to lowercase
+     *   decode all percent encoded triplets (including unreserved)
+     *   encode any that need to be encodedparsingutils
+     *
+     * URL without a scheme is treated as invalid
+     */
+    implicit val config: UriConfig = UriConfig.default.copy(queryEncoder = PercentEncoder())
+
+    try {
+      // parsing decodes the percent encoded triplets, including unreserved chars
+      val parsed = Uri.parse(uriStr)
+      parsed match {
+        case url: Url =>
+          if (url.schemeOption.isEmpty) throw new UriDecodeException("Scheme is empty")
+          // lowercase schema
+          val schemeNormalized = url.schemeOption.map(_.toLowerCase())
+
+          // lowercase host if not IP
+          val hostNormalized = url.hostOption.map(_.normalize)
+
+          // removes dot segments and extra //
+          val pathNormalized = url.path.normalize(removeEmptyParts = true)
+
+          // remove unneeded ports
+          val portNormalized = url.port.flatMap { (port: Int) =>
+            schemeNormalized match {
+              case Some(scheme) =>
+                scheme match {
+                  case "http"       => if (port == 80) None else Some(port)
+                  case "https"      => if (port == 443) None else Some(port)
+                  case "ftp"        => if (port == 21) None else Some(port)
+                  case "ws" | "wss" => if (port == 80) None else Some(port)
+                  case _            => Some(port)
+                }
+              case None => Some(port)
+            }
+          }
+
+          val queryNormalized = {
+            // filter duplicate keys (last one stays) and sort alphabetically (by key)
+            val filtered = url.query.params.toMap.toVector.sortBy(_._1)
+            QueryString(filtered)
+          }
+
+          // construction of the instance encodes all special characters that are disallowed in path and query
+          val urlNormalized = Url(
+            scheme = schemeNormalized.orNull,
+            user = url.user.orNull,
+            password = url.password.orNull,
+            host = hostNormalized.map(_.toString).orNull,
+            port = portNormalized.getOrElse(-1),
+            path = pathNormalized.toString,
+            query = queryNormalized,
+            fragment = url.fragment.orNull
+          )
+
+          Some(urlNormalized.toString)
+
+        case urn: Urn =>
+          Some(urn.toString.toLowerCase)
+      }
+    } catch {
+      case _: Exception => None
+    }
+  }
+
+  /** Checks if a string is a valid URI fragment according to <a
+    * href="https://www.rfc-editor.org/rfc/rfc3986#section-3.5">RFC&nbsp;3986&nbsp;section-3.5</a>
+    *
+    * @param str
+    * @return
+    *   true if str is a valid URI fragment, otherwise false
+    */
+  def isValidUriFragment(str: String): Boolean = {
+
+    /*
+     * Alphanumeric characters (A-Z, a-z, 0-9)
+     * Some special characters: -._~!$&'()*+,;=:@
+     * Percent-encoded characters, which are represented by the pattern %[0-9A-Fa-f]{2}
+     */
+    val uriFragmentRegex = "^([A-Za-z0-9\\-._~!$&'()*+,;=:@/?]|%[0-9A-Fa-f]{2})*$".r
+
+    // In general, empty URI fragment is a valid fragment, but for our use-case it would be pointless
+    str.nonEmpty && uriFragmentRegex.matches(str)
+  }
+}

--- a/castor/lib/core/src/test/scala/io/iohk/atala/castor/core/util/DIDOperationValidatorSpec.scala
+++ b/castor/lib/core/src/test/scala/io/iohk/atala/castor/core/util/DIDOperationValidatorSpec.scala
@@ -1,6 +1,6 @@
 package io.iohk.atala.castor.core.util
 
-import java.net.{URI, URL}
+import io.lemonlabs.uri.Uri
 import io.iohk.atala.shared.models.HexStrings.*
 import io.iohk.atala.shared.models.Base64UrlStrings.*
 import io.iohk.atala.castor.core.model.did.{
@@ -102,7 +102,7 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
           Service(
             id = s"service$i",
             `type` = ServiceType.LinkedDomains,
-            serviceEndpoint = Seq(URI.create("http://example.com"))
+            serviceEndpoint = Seq(Uri.parse("http://example.com/"))
           )
         )
         val op = createPrismDIDOperation(services = services)
@@ -115,7 +115,7 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
           Service(
             id = s"service0",
             `type` = ServiceType.LinkedDomains,
-            serviceEndpoint = Seq(URI.create("http://example.com"))
+            serviceEndpoint = Seq(Uri.parse("http://example.com/"))
           )
         )
         val op = createPrismDIDOperation(services = services)
@@ -141,7 +141,7 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
           Service(
             id = s"service $i",
             `type` = ServiceType.LinkedDomains,
-            serviceEndpoint = Seq(URI.create("http://example.com"))
+            serviceEndpoint = Seq(Uri.parse("http://example.com/"))
           )
         )
         val op = createPrismDIDOperation(services = services)
@@ -176,7 +176,7 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
               id = "service-0",
               `type` = ServiceType.LinkedDomains,
               serviceEndpoint = Seq(
-                URI.create("http://example.com/login/../login")
+                Uri.parse("http://example.com/login/../login")
               )
             )
           )
@@ -207,15 +207,15 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
             UpdateDIDAction.AddInternalKey(InternalPublicKey("master0", InternalKeyPurpose.Master, publicKeyData)),
             UpdateDIDAction.RemoveKey("key0"),
             UpdateDIDAction.AddService(
-              Service("service0", ServiceType.LinkedDomains, Seq(URI.create("http://example.com")))
+              Service("service0", ServiceType.LinkedDomains, Seq(Uri.parse("http://example.com/")))
             ),
             UpdateDIDAction.RemoveService("service0"),
             UpdateDIDAction.UpdateService("service0", Some(ServiceType.LinkedDomains), Nil),
-            UpdateDIDAction.UpdateService("service0", None, Seq(URI.create("http://example.com"))),
+            UpdateDIDAction.UpdateService("service0", None, Seq(Uri.parse("http://example.com/"))),
             UpdateDIDAction.UpdateService(
               "service0",
               Some(ServiceType.LinkedDomains),
-              Seq(URI.create("http://example.com"))
+              Seq(Uri.parse("http://example.com/"))
             )
           )
         )
@@ -252,7 +252,7 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
             Service(
               id = s"service$i",
               `type` = ServiceType.LinkedDomains,
-              serviceEndpoint = Seq(URI.create("http://example.com"))
+              serviceEndpoint = Seq(Uri.parse("http://example.com/"))
             )
           )
         )
@@ -261,7 +261,7 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
           UpdateDIDAction.UpdateService(
             s"update$i",
             Some(ServiceType.LinkedDomains),
-            Seq(URI.create("http://example.com"))
+            Seq(Uri.parse("http://example.com/"))
           )
         )
         val op = updatePrismDIDOperation(addServiceActions ++ removeServiceActions ++ updateServiceActions)
@@ -288,7 +288,7 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
           Service(
             id = "service 1",
             `type` = ServiceType.LinkedDomains,
-            serviceEndpoint = Seq(URI.create("http://example.com"))
+            serviceEndpoint = Seq(Uri.parse("http://example.com/"))
           )
         )
         val action2 = UpdateDIDAction.RemoveService(id = "service 2")
@@ -321,7 +321,7 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
         val op = updatePrismDIDOperation(
           Seq(
             UpdateDIDAction.AddService(
-              Service("service-1", ServiceType.LinkedDomains, Seq(URI.create("http://example.com/login/../login")))
+              Service("service-1", ServiceType.LinkedDomains, Seq(Uri.parse("http://example.com/login/../login")))
             )
           )
         )
@@ -331,7 +331,7 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
       },
       test("reject updateOperation when action UpdateService serviceEndpoint is not normalized") {
         val op = updatePrismDIDOperation(
-          Seq(UpdateDIDAction.UpdateService("service-1", None, Seq(URI.create("http://example.com/login/../login"))))
+          Seq(UpdateDIDAction.UpdateService("service-1", None, Seq(Uri.parse("http://example.com/login/../login"))))
         )
         assert(DIDOperationValidator(Config(50, 50)).validate(op))(
           invalidArgumentContainsString("serviceEndpoint URIs must be normalized")

--- a/castor/lib/project/Dependencies.scala
+++ b/castor/lib/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
     val prismSdk = "v1.4.1" // scala-steward:off
     val shared = "0.2.0"
     val flyway = "9.8.3"
+    val scalaUri = "4.0.3"
   }
 
   private lazy val zio = "dev.zio" %% "zio" % Versions.zio
@@ -23,6 +24,8 @@ object Dependencies {
 
   private lazy val flyway = "org.flywaydb" % "flyway-core" % Versions.flyway
 
+  private lazy val scalaUri = "io.lemonlabs" %% "scala-uri" % Versions.scalaUri
+
   private lazy val shared = "io.iohk.atala" % "shared" % Versions.shared
   private lazy val prismNodeClient = "io.iohk.atala" %% "prism-node-client" % Versions.prismNodeClient
 
@@ -35,7 +38,7 @@ object Dependencies {
   private lazy val prismIdentity = "io.iohk.atala" % "prism-identity-jvm" % Versions.prismSdk
 
   // Dependency Modules
-  private lazy val baseDependencies: Seq[ModuleID] = Seq(zio, zioTest, zioTestSbt, zioTestMagnolia, shared, prismCrypto, prismIdentity, prismNodeClient)
+  private lazy val baseDependencies: Seq[ModuleID] = Seq(zio, zioTest, zioTestSbt, zioTestMagnolia, shared, prismCrypto, prismIdentity, prismNodeClient, scalaUri)
   private lazy val doobieDependencies: Seq[ModuleID] = Seq(doobiePostgres, doobieHikari, flyway)
 
   // Project Dependencies


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes ATL-xxxx. Current version of Castor uses `java.net.URI` which implements URI according to RFC2396. In Prism DID specificaition, the URI used by `serviceEndpoint` in DID document should conform to RFC3986. This PR remove the use of `java.net.URI` and move to different URI class conforming to the correct RFC.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
