### PR TITLE
fix(pollux): exclude scala-java8-compat to fix 56f7aab7d3f58de51691271e1708edecc67b51b0

### DIFF
--- a/pollux/lib/project/Dependencies.scala
+++ b/pollux/lib/project/Dependencies.scala
@@ -39,7 +39,8 @@ object Dependencies {
 
   private lazy val flyway = "org.flywaydb" % "flyway-core" % Versions.flyway
 
-  private lazy val quillJdbcZio = "io.getquill" %% "quill-jdbc-zio" % Versions.quill
+  private lazy val quillJdbcZio =
+    "io.getquill" %% "quill-jdbc-zio" % Versions.quill exclude ("org.scala-lang.modules", "scala-java8-compat_3")
   private lazy val quillDoobie =
     "io.getquill" %% "quill-doobie" % Versions.quill exclude ("org.scala-lang.modules", "scala-java8-compat_3")
   private lazy val testcontainers =


### PR DESCRIPTION


# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
fix(pollux): exclude scala-java8-compat to fix 56f7aab7d3f58de51691271e1708edecc67b51b0