### PR TITLE
docs(prism-agent): insert bouncy-castle security as 2nd provider

### DIFF
--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/Main.scala
@@ -1,5 +1,6 @@
 package io.iohk.atala.agent.server
 
+import com.nimbusds.jose.crypto.bc.BouncyCastleProviderSingleton
 import zio.*
 import io.iohk.atala.mercury.*
 import org.didcommx.didcomm.DIDComm
@@ -26,6 +27,8 @@ import io.circe.generic.auto.*
 import io.circe.parser.*
 import io.circe.syntax.*
 import io.iohk.atala.agent.server.health.HealthInfo
+
+import java.security.Security
 
 object SystemInfoApp extends ZIOAppDefault {
   private val metricsConfig = ZLayer.succeed(MetricsConfig(5.seconds))
@@ -63,6 +66,8 @@ object SystemInfoApp extends ZIOAppDefault {
 }
 
 object AgentApp extends ZIOAppDefault {
+
+  Security.insertProviderAt(BouncyCastleProviderSingleton.getInstance(), 2)
 
   def didCommAgentLayer(didCommServiceUrl: String): ZLayer[ManagedDIDService, Nothing, DidAgent] = {
     val aux = for {


### PR DESCRIPTION
Insert bouncy-castle security as 2nd provider globally in the agent entry point

# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes ATL-xxxx

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
