### PR TITLE
feat: add general test postgresql container support

### DIFF
--- a/shared/project/Dependencies.scala
+++ b/shared/project/Dependencies.scala
@@ -4,10 +4,14 @@ object Dependencies {
   object Versions {
     val typesafeConfig = "1.4.2"
     val protobuf = "3.1.9"
+    val testContainersScalaPostgresql = "0.40.11"
   }
 
   private lazy val typesafeConfig = "com.typesafe" % "config" % Versions.typesafeConfig
   private lazy val scalaPbGrpc = "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
+  private lazy val testcontainers =
+    "com.dimafeng" %% "testcontainers-scala-postgresql" % Versions.testContainersScalaPostgresql
 
-  lazy val dependencies: Seq[ModuleID] = Seq(typesafeConfig, scalaPbGrpc)
+
+  lazy val dependencies: Seq[ModuleID] = Seq(typesafeConfig, scalaPbGrpc, testcontainers)
 }

--- a/shared/src/main/scala/io/iohk/atala/shared/test/containers/PostgreSQLContainerCustom.scala
+++ b/shared/src/main/scala/io/iohk/atala/shared/test/containers/PostgreSQLContainerCustom.scala
@@ -1,0 +1,54 @@
+package io.iohk.atala.shared.test.containers
+
+import com.dimafeng.testcontainers.{JdbcDatabaseContainer, PostgreSQLContainer}
+import org.testcontainers.containers.output.OutputFrame
+import org.testcontainers.utility.DockerImageName
+
+import java.util.function.Consumer
+
+class PostgreSQLContainerCustom(
+    dockerImageNameOverride: Option[DockerImageName] = None,
+    databaseName: Option[String] = None,
+    pgUsername: Option[String] = None,
+    pgPassword: Option[String] = None,
+    mountPostgresDataToTmpfs: Boolean = false,
+    urlParams: Map[String, String] = Map.empty,
+    commonJdbcParams: JdbcDatabaseContainer.CommonParams = JdbcDatabaseContainer.CommonParams()
+) extends PostgreSQLContainer(
+      dockerImageNameOverride,
+      databaseName,
+      pgUsername,
+      pgPassword,
+      mountPostgresDataToTmpfs,
+      urlParams,
+      commonJdbcParams
+    ) {
+
+  override def jdbcUrl: String = {
+    /* This is such a hack!
+     *
+     * We are running PostgreSQL test containers inside a bridged (user-derfined)
+     * network.  Testcontainers expects to be able to connect to the _host_ and
+     * map ports on the host.  However we are running _inside_ a docker container.
+     * So now the mapping to _localhost:randomport_ -> spawned postgres:5432 is
+     * available from _outside_, but not form the docker container actually
+     * spawning the others.
+     *
+     * We also can't refer to them by name, because docker somehow fails to
+     * resolve names sometimes once a container has joined a network but didn't
+     * get a name assigned when joining :shurg:.
+     *
+     * We can however refer to containers by their containerId, or more
+     * precisely by their _short_ (first 12 char) Id.
+     *
+     * So we overwrite the jdbcUrl, and change the way it's constructed in test
+     * containers.
+     *
+     * This is a mess :(
+     */
+    val origUrl = super.jdbcUrl
+    val idx = origUrl.indexOf('?')
+    val params = if (idx >= 0) origUrl.substring(idx) else ""
+    s"jdbc:postgresql://${containerId.take(12)}:5432/${super.databaseName}${params}"
+  }
+}

--- a/shared/src/main/scala/io/iohk/atala/shared/test/containers/PostgresTestContainer.scala
+++ b/shared/src/main/scala/io/iohk/atala/shared/test/containers/PostgresTestContainer.scala
@@ -1,0 +1,25 @@
+package io.iohk.atala.shared.test.containers
+
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import org.testcontainers.containers.output.OutputFrame
+import org.testcontainers.utility.DockerImageName
+
+object PostgresTestContainer {
+  def postgresContainer(imageName: Option[String] = Some("postgres"),
+                        verbose: Boolean = false) = {
+    val container =
+      if (sys.env.contains("GITHUB_NETWORK"))
+        new PostgreSQLContainerCustom(dockerImageNameOverride = imageName.map(DockerImageName.parse))
+      else
+        new PostgreSQLContainer(dockerImageNameOverride = imageName.map(DockerImageName.parse))
+    sys.env.get("GITHUB_NETWORK").map { network =>
+      container.container.withNetworkMode(network)
+    }
+    if (verbose) {
+      container.container
+        .withLogConsumer((t: OutputFrame) => println(t.getUtf8String))
+        .withCommand("postgres", "-c", "log_statement=all", "-c", "log_destination=stderr")
+    }
+    container
+  }
+}


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Adds general unified PostgreSQL testcontainer support in shared module to use in all unit tests across modules.

Will be integrated as part of: https://github.com/input-output-hk/atala-prism-building-blocks/pull/474

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [x] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [x] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
