### PR TITLE
test(castor): corner cases for DIDOperationValidatorSpec

### DIFF
--- a/castor/lib/core/src/test/scala/io/iohk/atala/castor/core/util/DIDOperationValidatorSpec.scala
+++ b/castor/lib/core/src/test/scala/io/iohk/atala/castor/core/util/DIDOperationValidatorSpec.scala
@@ -262,11 +262,9 @@ object DIDOperationValidatorSpec extends ZIOSpecDefault {
           invalidArgumentContainsString("serviceEndpoint URIs must be normalized")
         )
       },
-      test("reject CreateOperation when publicKeys is empty") {
+      test("accept CreateOperation when publicKeys is empty because master key always exist") {
         val op = createPrismDIDOperation(publicKeys = Nil)
-        assert(DIDOperationValidator(Config(50, 50)).validate(op))(
-          invalidArgumentContainsString("operation must contain at least 1 public key")
-        )
+        assert(DIDOperationValidator(Config(50, 50)).validate(op))(isRight)
       },
       // Test that the validator accepts a CreateOperation when the services list is not present
       test("accept CreateOperation when services is None") {


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Corner cases tests for Castor `DIDOperationValidatorSpec` that were generated by ChatGPT + Copilot,
coverage for this class increased to 100%.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [x] If yes to above: I have taken care to cover edge cases in my tests
