### PR TITLE
chore: remove asterix from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,3 @@
 
 # Docs:
 /docs/ @antonbaliasnikov @davidpoltorak-io @yshyn-iohk @BS-IO 
-
-# Everything else will be reviewed by someone from the Atala group
-* @input-output-hk/atala


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Remove asterix from codeowners to not assign wrong reviewers

