### PR TITLE
fix(prism-agent): log error if seed validation fails

### DIFF
--- a/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/util/SeedResolver.scala
+++ b/prism-agent/service/wallet-api/src/main/scala/io/iohk/atala/agent/walletapi/util/SeedResolver.scala
@@ -52,7 +52,12 @@ private class SeedResolverImpl(apollo: Apollo, isDevMode: Boolean) extends SeedR
         case Some(seed) => ZIO.succeed(seed)
         case None       => seedRand
       }
-      .flatMap(seed => ZIO.fromEither(validateSeed(seed)).mapError(Exception(_)).as(seed))
+      .tap(seed =>
+        ZIO
+          .fromEither(validateSeed(seed))
+          .tapError(e => ZIO.logError(e))
+          .mapError(Exception(_))
+      )
   }
 
   private def validateSeed(seed: Array[Byte]): Either[String, Unit] = {


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes ATL-4934

Added an error log when seed validation fails. Instead of endlessly finding the right exception in the stack trace, the real error is logged before the program crash.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
