### PR TITLE
test: add different auth support per cloud agent in e2e

### DIFF
--- a/tests/e2e-tests/src/test/kotlin/common/Agents.kt
+++ b/tests/e2e-tests/src/test/kotlin/common/Agents.kt
@@ -15,22 +15,16 @@ object Agents {
     lateinit var Faber: Actor
         private set
 
-    init {
-        if (Environments.AGENT_AUTH_REQUIRED) {
-            SerenityRest.setDefaultRequestSpecification(
-                RequestSpecBuilder().addHeader(
-                    Environments.AGENT_AUTH_HEADER,
-                    Environments.AGENT_AUTH_KEY,
-                )
-                    .build(),
-            )
-        }
-    }
-
     fun createAgents() {
         Acme = Actor.named("Acme").whoCan(CallAnApi.at(Environments.ACME_AGENT_URL))
         Bob = Actor.named("Bob").whoCan(CallAnApi.at(Environments.BOB_AGENT_URL))
         Mallory = Actor.named("Mallory").whoCan(CallAnApi.at(Environments.MALLORY_AGENT_URL))
         Faber = Actor.named("Faber").whoCan(CallAnApi.at(Environments.FABER_AGENT_URL))
+        if (Environments.AGENT_AUTH_REQUIRED) {
+            Acme.remember("AUTH_KEY", Environments.ACME_AUTH_KEY)
+            Bob.remember("AUTH_KEY", Environments.BOB_AUTH_KEY)
+            Mallory.remember("AUTH_KEY", Environments.MALLORY_AUTH_KEY)
+            Faber.remember("AUTH_KEY", Environments.FABER_AUTH_KEY)
+        }
     }
 }

--- a/tests/e2e-tests/src/test/kotlin/common/Environments.kt
+++ b/tests/e2e-tests/src/test/kotlin/common/Environments.kt
@@ -3,9 +3,12 @@ package common
 object Environments {
     val AGENT_AUTH_REQUIRED: Boolean = System.getenv("AGENT_AUTH_REQUIRED").toBoolean()
     val AGENT_AUTH_HEADER = System.getenv("AGENT_AUTH_HEADER") ?: "apikey"
-    val AGENT_AUTH_KEY = System.getenv("AGENT_AUTH_KEY") ?: ""
+    val ACME_AUTH_KEY = System.getenv("ACME_AUTH_KEY") ?: ""
     val ACME_AGENT_URL = System.getenv("ACME_AGENT_URL") ?: "http://localhost:8080/prism-agent"
     val BOB_AGENT_URL = System.getenv("BOB_AGENT_URL") ?: "http://localhost:8090/prism-agent"
+    val BOB_AUTH_KEY = System.getenv("BOB_AUTH_KEY") ?: ""
     val MALLORY_AGENT_URL = System.getenv("MALLORY_AGENT_URL") ?: "http://localhost:8070/prism-agent"
+    val MALLORY_AUTH_KEY = System.getenv("MALLORY_AUTH_KEY") ?: ""
     val FABER_AGENT_URL = System.getenv("FABER_AGENT_URL") ?: "http://localhost:8070/prism-agent"
+    val FABER_AUTH_KEY = System.getenv("FABER_AUTH_KEY") ?: ""
 }

--- a/tests/e2e-tests/src/test/kotlin/features/CommonSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/CommonSteps.kt
@@ -15,11 +15,6 @@ import features.issue_credentials.IssueCredentialsSteps
 import io.cucumber.java.Before
 import io.cucumber.java.ParameterType
 import io.cucumber.java.en.Given
-import io.restassured.RestAssured
-import io.restassured.config.ObjectMapperConfig
-import io.restassured.config.ObjectMapperConfig.objectMapperConfig
-import io.restassured.config.RestAssuredConfig
-import io.restassured.mapper.ObjectMapperType
 import net.serenitybdd.screenplay.Actor
 import net.serenitybdd.screenplay.actors.Cast
 import net.serenitybdd.screenplay.actors.OnStage

--- a/tests/e2e-tests/src/test/kotlin/features/connection/ConnectionSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/connection/ConnectionSteps.kt
@@ -5,11 +5,11 @@ import api_models.ConnectionState
 import api_models.Invitation
 import common.Utils.lastResponseObject
 import common.Utils.wait
+import interactions.Get
+import interactions.Post
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Get
-import net.serenitybdd.screenplay.rest.interactions.Post
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus.SC_CREATED
 import org.apache.http.HttpStatus.SC_OK

--- a/tests/e2e-tests/src/test/kotlin/features/credential_schemas/CredentialSchemasSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/credential_schemas/CredentialSchemasSteps.kt
@@ -10,8 +10,8 @@ import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import io.restassured.path.json.JsonPath
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Get
-import net.serenitybdd.screenplay.rest.interactions.Post
+import interactions.Get
+import interactions.Post
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus.*
 import org.hamcrest.CoreMatchers.*

--- a/tests/e2e-tests/src/test/kotlin/features/did/DeactivateDidSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/did/DeactivateDidSteps.kt
@@ -6,8 +6,8 @@ import common.Utils.lastResponseObject
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Get
-import net.serenitybdd.screenplay.rest.interactions.Post
+import interactions.Get
+import interactions.Post
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus
 import org.hamcrest.Matchers

--- a/tests/e2e-tests/src/test/kotlin/features/did/ManageDidSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/did/ManageDidSteps.kt
@@ -10,8 +10,8 @@ import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import net.serenitybdd.rest.SerenityRest.lastResponse
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Get
-import net.serenitybdd.screenplay.rest.interactions.Post
+import interactions.Get
+import interactions.Post
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus.SC_CREATED
 import org.assertj.core.api.Assertions

--- a/tests/e2e-tests/src/test/kotlin/features/did/PublishDidSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/did/PublishDidSteps.kt
@@ -10,8 +10,8 @@ import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import net.serenitybdd.rest.SerenityRest
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Get
-import net.serenitybdd.screenplay.rest.interactions.Post
+import interactions.Get
+import interactions.Post
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus.*
 import org.assertj.core.api.Assertions.assertThat

--- a/tests/e2e-tests/src/test/kotlin/features/did/UpdateDidSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/did/UpdateDidSteps.kt
@@ -7,8 +7,8 @@ import common.Utils.wait
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Get
-import net.serenitybdd.screenplay.rest.interactions.Post
+import interactions.Get
+import interactions.Post
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus
 import org.hamcrest.Matchers.emptyString

--- a/tests/e2e-tests/src/test/kotlin/features/issue_credentials/IssueCredentialsSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/issue_credentials/IssueCredentialsSteps.kt
@@ -8,8 +8,8 @@ import common.Utils.wait
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Get
-import net.serenitybdd.screenplay.rest.interactions.Post
+import interactions.Get
+import interactions.Post
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus.SC_CREATED
 import org.apache.http.HttpStatus.SC_OK

--- a/tests/e2e-tests/src/test/kotlin/features/present_proof/PresentProofSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/present_proof/PresentProofSteps.kt
@@ -9,9 +9,9 @@ import common.Utils.wait
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Get
-import net.serenitybdd.screenplay.rest.interactions.Patch
-import net.serenitybdd.screenplay.rest.interactions.Post
+import interactions.Get
+import interactions.Post
+import interactions.Patch
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus.SC_CREATED
 import org.apache.http.HttpStatus.SC_OK

--- a/tests/e2e-tests/src/test/kotlin/features/system/SystemSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/system/SystemSteps.kt
@@ -5,7 +5,7 @@ import common.Utils.lastResponseObject
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Get
+import interactions.Get
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus.SC_OK
 import org.assertj.core.api.Assertions.assertThat

--- a/tests/e2e-tests/src/test/kotlin/features/verification_policies/VerificationPoliciesSteps.kt
+++ b/tests/e2e-tests/src/test/kotlin/features/verification_policies/VerificationPoliciesSteps.kt
@@ -7,8 +7,8 @@ import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import net.serenitybdd.rest.SerenityRest
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.interactions.Post
-import net.serenitybdd.screenplay.rest.interactions.Put
+import interactions.Put
+import interactions.Post
 import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
 import org.apache.http.HttpStatus
 import org.hamcrest.CoreMatchers

--- a/tests/e2e-tests/src/test/kotlin/interactions/Delete.kt
+++ b/tests/e2e-tests/src/test/kotlin/interactions/Delete.kt
@@ -1,0 +1,30 @@
+package interactions
+
+import common.Environments
+import net.serenitybdd.screenplay.Actor
+import net.serenitybdd.screenplay.Tasks
+import net.serenitybdd.screenplay.rest.abilities.CallAnApi
+import net.serenitybdd.screenplay.rest.interactions.RestInteraction
+import net.thucydides.core.annotations.Step
+
+
+/**
+ * This class is a copy of the class Delete from serenity rest interactions
+ * to add a custom authentication header to the request on-the-fly.
+ */
+open class Delete(private val resource: String) : RestInteraction() {
+    @Step("{0} executes a DELETE on the resource #resource")
+    override fun <T : Actor?> performAs(actor: T) {
+        val spec = rest()
+        if (Environments.AGENT_AUTH_REQUIRED) {
+            spec.header(Environments.AGENT_AUTH_HEADER, actor!!.recall("AUTH_KEY"))
+        }
+        spec.delete(CallAnApi.`as`(actor).resolve(resource))
+    }
+
+    companion object {
+        fun from(resource: String?): Delete {
+            return Tasks.instrumented(Delete::class.java, resource)
+        }
+    }
+}

--- a/tests/e2e-tests/src/test/kotlin/interactions/Get.kt
+++ b/tests/e2e-tests/src/test/kotlin/interactions/Get.kt
@@ -1,0 +1,29 @@
+package interactions
+
+import common.Environments
+import net.serenitybdd.screenplay.Actor
+import net.serenitybdd.screenplay.Tasks
+import net.serenitybdd.screenplay.rest.abilities.CallAnApi
+import net.serenitybdd.screenplay.rest.interactions.RestInteraction
+import net.thucydides.core.annotations.Step
+
+/**
+ * This class is a copy of the class Get from serenity rest interactions
+ * to add a custom authentication header to the request on-the-fly.
+ */
+open class Get(private val resource: String) : RestInteraction() {
+    @Step("{0} executes a GET on the resource #resource")
+    override fun <T : Actor?> performAs(actor: T) {
+        val spec = rest()
+        if (Environments.AGENT_AUTH_REQUIRED) {
+            spec.header(Environments.AGENT_AUTH_HEADER, actor!!.recall("AUTH_KEY"))
+        }
+        spec.get(CallAnApi.`as`(actor).resolve(resource))
+    }
+
+    companion object {
+        fun resource(resource: String?): Get {
+            return Tasks.instrumented(Get::class.java, resource)
+        }
+    }
+}

--- a/tests/e2e-tests/src/test/kotlin/interactions/Patch.kt
+++ b/tests/e2e-tests/src/test/kotlin/interactions/Patch.kt
@@ -1,0 +1,29 @@
+package interactions
+
+import common.Environments
+import net.serenitybdd.screenplay.Actor
+import net.serenitybdd.screenplay.Tasks
+import net.serenitybdd.screenplay.rest.abilities.CallAnApi
+import net.serenitybdd.screenplay.rest.interactions.RestInteraction
+import net.thucydides.core.annotations.Step
+
+/**
+ * This class is a copy of the class Patch from serenity rest interactions
+ * to add a custom authentication header to the request on-the-fly.
+ */
+open class Patch(private val resource: String) : RestInteraction() {
+    @Step("{0} executes a PATCH on the resource #resource")
+    override fun <T : Actor?> performAs(actor: T) {
+        val spec = rest()
+        if (Environments.AGENT_AUTH_REQUIRED) {
+            spec.header(Environments.AGENT_AUTH_HEADER, actor!!.recall("AUTH_KEY"))
+        }
+        spec.patch(CallAnApi.`as`(actor).resolve(resource))
+    }
+
+    companion object {
+        fun to(resource: String?): Patch {
+            return Tasks.instrumented(Patch::class.java, resource)
+        }
+    }
+}

--- a/tests/e2e-tests/src/test/kotlin/interactions/Post.kt
+++ b/tests/e2e-tests/src/test/kotlin/interactions/Post.kt
@@ -1,0 +1,29 @@
+package interactions
+
+import common.Environments
+import net.serenitybdd.screenplay.Actor
+import net.serenitybdd.screenplay.Tasks
+import net.serenitybdd.screenplay.rest.abilities.CallAnApi
+import net.serenitybdd.screenplay.rest.interactions.RestInteraction
+import net.thucydides.core.annotations.Step
+
+/**
+ * This class is a copy of the class Post from serenity rest interactions
+ * to add a custom authentication header to the request on-the-fly.
+ */
+open class Post(private val resource: String) : RestInteraction() {
+    @Step("{0} executes a POST on the resource #resource")
+    override fun <T : Actor?> performAs(actor: T) {
+        val spec = rest()
+        if (Environments.AGENT_AUTH_REQUIRED) {
+            spec.header(Environments.AGENT_AUTH_HEADER, actor!!.recall("AUTH_KEY"))
+        }
+        spec.post(CallAnApi.`as`(actor).resolve(resource))
+    }
+
+    companion object {
+        fun to(resource: String?): Post {
+            return Tasks.instrumented(Post::class.java, resource)
+        }
+    }
+}

--- a/tests/e2e-tests/src/test/kotlin/interactions/Put.kt
+++ b/tests/e2e-tests/src/test/kotlin/interactions/Put.kt
@@ -1,0 +1,30 @@
+package interactions
+
+import common.Environments
+import net.serenitybdd.screenplay.Actor
+import net.serenitybdd.screenplay.Tasks
+import net.serenitybdd.screenplay.rest.abilities.CallAnApi
+import net.serenitybdd.screenplay.rest.interactions.RestInteraction
+import net.thucydides.core.annotations.Step
+
+
+/**
+ * This class is a copy of the class Put from serenity rest interactions
+ * to add a custom authentication header to the request on-the-fly.
+ */
+open class Put(private val resource: String) : RestInteraction() {
+    @Step("{0} executes a PUT on the resource #resource")
+    override fun <T : Actor?> performAs(actor: T) {
+        val spec = rest()
+        if (Environments.AGENT_AUTH_REQUIRED) {
+            spec.header(Environments.AGENT_AUTH_HEADER, actor!!.recall("AUTH_KEY"))
+        }
+        spec.put(CallAnApi.`as`(actor).resolve(resource))
+    }
+
+    companion object {
+        fun to(resource: String?): Put {
+            return Tasks.instrumented(Put::class.java, resource)
+        }
+    }
+}


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Adds auth per agent support in e2e tests to be able to run in remote environment

## Checklist

### My PR contains...
* [x] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [x] If yes to above: I have taken care to cover edge cases in my tests
