### PR TITLE
test: silence migration loggers in tests

### DIFF
--- a/connect/lib/sql-doobie/src/test/resources/logback.xml
+++ b/connect/lib/sql-doobie/src/test/resources/logback.xml
@@ -10,9 +10,14 @@
         <appender-ref ref="STDOUT"/>
     </appender>
 
+    <logger name="io.getquill" level="OFF"/>
     <logger name="com.zaxxer.hikari" level="OFF"/>
 
-    <root level="INFO">
+    <!--
+    INFO level is too noisy because of flyway migration log when running "sbt test".
+    If root level set to INFO, we should also set flyway logLevel to WARN
+    -->
+    <root level="WARN">
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 

--- a/connect/lib/sql-doobie/src/test/scala/io/iohk/atala/connect/sql/repository/JdbcConnectionRepositorySpec.scala
+++ b/connect/lib/sql-doobie/src/test/scala/io/iohk/atala/connect/sql/repository/JdbcConnectionRepositorySpec.scala
@@ -36,4 +36,5 @@ object JdbcConnectionRepositorySpec extends ZIOSpecDefault {
     ) @@ TestAspect.sequential @@ TestAspect.before(
       ZIO.serviceWithZIO[Migrations](_.migrate)
     )).provide(testEnvironmentLayer)
+      .provide(Runtime.removeDefaultLoggers)
 }

--- a/pollux/lib/sql-doobie/src/test/scala/io/iohk/atala/pollux/sql/repository/JdbcCredentialRepositorySpec.scala
+++ b/pollux/lib/sql-doobie/src/test/scala/io/iohk/atala/pollux/sql/repository/JdbcCredentialRepositorySpec.scala
@@ -34,5 +34,6 @@ object JdbcCredentialRepositorySpec extends ZIOSpecDefault {
     ) @@ TestAspect.before(
       ZIO.serviceWithZIO[Migrations](_.migrate)
     )).provide(testEnvironmentLayer)
+      .provide(Runtime.removeDefaultLoggers)
 
 }

--- a/pollux/lib/sql-doobie/src/test/scala/io/iohk/atala/pollux/sql/repository/JdbcPresentationRepositorySpec.scala
+++ b/pollux/lib/sql-doobie/src/test/scala/io/iohk/atala/pollux/sql/repository/JdbcPresentationRepositorySpec.scala
@@ -34,5 +34,6 @@ object JdbcPresentationRepositorySpec extends ZIOSpecDefault {
     ) @@ TestAspect.before(
       ZIO.serviceWithZIO[Migrations](_.migrate)
     )).provide(testEnvironmentLayer)
+      .provide(Runtime.removeDefaultLoggers)
 
 }

--- a/prism-agent/service/server/src/test/resources/logback.xml
+++ b/prism-agent/service/server/src/test/resources/logback.xml
@@ -13,7 +13,11 @@
     <logger name="io.getquill" level="OFF"/>
     <logger name="com.zaxxer.hikari" level="OFF"/>
 
-    <root level="INFO">
+    <!--
+    INFO level is too noisy because of flyway migration log when running "sbt test".
+    If root level set to INFO, we should also set flyway logLevel to WARN
+    -->
+    <root level="WARN">
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

During refactoring for MT, Running local tests is somewhat painful scraping through test logs, especially migration logs which aren't that useful.

The migration loggers are now silenced, now the logs look like this
```
+ JDBC Connection Repository test suite
  + CRUD operations
    + createConnectionRecord creates a new record in DB
    + createConnectionRecord prevents creation of 2 records with the same thid
    + getConnectionRecord correctly returns an existing record
    + getConnectionRecord returns None for an unknown record
```
and not this
```
+ JDBC Connection Repository test suite
  + CRUD operations
[INFO] o.t.u.ImageNameSubstitutor - Image name substitution will be performed by: DefaultImageNameSubstitutor (composite of 'ConfigurationFileImageNameSubstitutor' and 'PrefixingImageNameSubstitutor')
[INFO] o.t.d.DockerClientProviderStrategy - Loaded org.testcontainers.dockerclient.UnixSocketClientProviderStrategy from ~/.testcontainers.properties, will try it first
[INFO] o.t.d.DockerClientProviderStrategy - Found Docker environment with local Unix socket (unix:///var/run/docker.sock)
[INFO] o.t.DockerClientFactory - Docker host IP address is localhost
[INFO] o.t.DockerClientFactory - Connected to docker:
  Server Version: 20.10.23
  API Version: 1.41
  Operating System: NixOS 23.05 (Stoat)
  Total Memory: 31323 MB
[INFO] t.t.4.0 - Creating container for image: testcontainers/ryuk:0.4.0
[INFO] t.t.4.0 - Container testcontainers/ryuk:0.4.0 is starting: 0b23fc271107908e41ae44144851967b4534c491a39cc72b10e8122fea9d09a5
[INFO] t.t.4.0 - Container testcontainers/ryuk:0.4.0 started in PT0.548931S
[INFO] o.t.u.RyukResourceReaper - Ryuk started - will monitor and terminate Testcontainers containers on JVM exit
[INFO] o.t.DockerClientFactory - Checking the system...
[INFO] o.t.DockerClientFactory - ✔ Docker server version should be at least 1.6.0
[INFO] t.postgres:latest - Creating container for image: postgres:latest
[INFO] t.postgres:latest - Container postgres:latest is starting: 0d1f899c4aa0a0ab29f6ca081345f933305d7f541cc6d8a3a5a7bcccbf4e7e0f
[INFO] t.postgres:latest - Container postgres:latest started in PT1.272857S
[INFO] t.postgres:latest - Container is started (JDBC URL: jdbc:postgresql://localhost:33995/test?loggerLevel=OFF)
timestamp=2023-08-03T09:44:14.379933Z level=INFO thread=#zio-fiber-74 message="Applying database migrations" location=io.iohk.atala.connect.sql.repository.Migrations.migrate file=Migrations.scala line=12
[INFO] o.f.c.i.l.VersionPrinter - Flyway Community Edition 9.8.3 by Redgate
[INFO] o.f.c.i.l.VersionPrinter - See what's new here: https://flywaydb.org/documentation/learnmore/releaseNotes#9.8.3
[INFO] o.f.c.i.l.VersionPrinter -
[INFO] o.f.c.i.d.b.BaseDatabaseType - Database: jdbc:postgresql://localhost:33995/test (PostgreSQL 15.3)
[INFO] o.f.c.i.c.DbValidate - Successfully validated 5 migrations (execution time 00:00.019s)
[INFO] o.f.c.i.s.JdbcTableSchemaHistory - Creating Schema History table "public"."flyway_schema_history" ...
[INFO] o.f.c.i.c.DbMigrate - Current version of schema "public": << Empty Schema >>
[INFO] o.f.c.i.c.DbMigrate - Migrating schema "public" to version "1 - init tables"
[INFO] o.f.c.i.c.DbMigrate - Migrating schema "public" to version "2 - add thid unique constraint"
[INFO] o.f.c.i.c.DbMigrate - Migrating schema "public" to version "3 - add meta retries and meta last failure"
[INFO] o.f.c.i.c.DbMigrate - Migrating schema "public" to version "4 - create protocol state index"
[INFO] o.f.c.i.c.DbMigrate - Migrating schema "public" to version "5 - add meta next retry"
[INFO] o.f.c.i.c.DbMigrate - Successfully applied 5 migrations to schema "public", now at version v5 (execution time 00:00.066s)
    + createConnectionRecord creates a new record in DB
```

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
