### PR TITLE
feat(pollux): add size and last used index to credential_status_lists table

### DIFF
--- a/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V17__add_size_and_available_index_to_credential_status_lists.sql
+++ b/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V17__add_size_and_available_index_to_credential_status_lists.sql
@@ -8,6 +8,6 @@ ALTER TABLE public.credential_status_lists
 ALTER TABLE public.credential_status_lists
     RENAME COLUMN encoded_list TO status_list_jwt_credential;
 
--- Change the data type of the 'encoded_list_credential' column to JSON
+-- Remove the column "proof"
 ALTER TABLE public.credential_status_lists
     DROP COLUMN proof


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
this PR adds extra columns to credential_status_list, and removes proof because it is included inside a jwt credential as a asignature

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [x] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [x] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests
