### PR TITLE
refactor(prism-agent): add metrics to status list background job

### DIFF
--- a/mercury/mercury-library/protocol-revocation-notification/Revocation-notification-protocol.md
+++ b/mercury/mercury-library/protocol-revocation-notification/Revocation-notification-protocol.md
@@ -23,6 +23,7 @@ Version 1.0: https://atalaprism.io/revocation_notification/1.0/revoke
 {
   "from": "fromDID_value",
   "to": "toDID_value",
+  "piuri":"https://atalaprism.io/revocation_notification/1.0/revoke",
   "body": {
     "issueCredentialProtocolThreadId": "issueCredentialProtocolThreadId_value",
     "comment": "Thread Id used to issue this credential withing issue credential protocol"

--- a/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
+++ b/prism-agent/service/server/src/main/scala/io/iohk/atala/agent/server/PrismAgentApp.scala
@@ -99,10 +99,10 @@ object PrismAgentApp {
   private val syncRevocationStatusListsJob = {
     for {
       config <- ZIO.service[AppConfig]
-      _ <- StatusListJobs.syncRevocationStatuses
-        .repeat(
-          Schedule.spaced(config.pollux.syncRevocationStatusesBgJobRecurrenceDelay)
-        )
+      _ <- (StatusListJobs.syncRevocationStatuses @@ Metric
+        .gauge("revocation_status_list_sync_job_ms_gauge")
+        .trackDurationWith(_.toMetricsSeconds))
+        .repeat(Schedule.spaced(config.pollux.syncRevocationStatusesBgJobRecurrenceDelay))
     } yield ()
   }
 


### PR DESCRIPTION
### Description: 
add performance metrics to revocation status list sync job

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-labs/open-enterprise-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
