### PR TITLE
fix(pollux): Undo edit migration for revocation status lists

### DIFF
--- a/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V16__revocation_status_lists_table_and_columns.sql
+++ b/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V16__revocation_status_lists_table_and_columns.sql
@@ -5,16 +5,15 @@ CREATE TYPE public.enum_credential_status_list_purpose AS ENUM (
 
 CREATE TABLE public.credential_status_lists
 (
-    id                     UUID PRIMARY KEY                                    default gen_random_uuid(),
-    wallet_id              UUID                                       NOT NULL,
-    issuer                 VARCHAR                                    NOT NULL,
-    issued                 TIMESTAMP WITH TIME ZONE                   NOT NULL,
-    purpose                public.enum_credential_status_list_purpose NOT NULL,
-    status_list_credential JSON                                       NOT NULL,
-    size                   INTEGER                                    NOT NULL DEFAULT 131072,
-    last_used_index        INTEGER                                    NOT NULL DEFAULT 0,
-    created_at             TIMESTAMP WITH TIME ZONE                   NOT NULL default now(),
-    updated_at             TIMESTAMP WITH TIME ZONE                   NOT NULL default now()
+    id           UUID PRIMARY KEY                                    default gen_random_uuid(),
+    wallet_id    UUID                                       NOT NULL,
+    issuer       VARCHAR                                    NOT NULL,
+    issued       TIMESTAMP WITH TIME ZONE                   NOT NULL,
+    purpose      public.enum_credential_status_list_purpose NOT NULL,
+    encoded_list TEXT                                       NOT NULL,
+    proof        JSON                                       NOT NULL,
+    created_at   TIMESTAMP WITH TIME ZONE                   NOT NULL default now(),
+    updated_at   TIMESTAMP WITH TIME ZONE                   NOT NULL default now()
 );
 
 CREATE INDEX credential_status_lists_wallet_id_index ON public.credential_status_lists (wallet_id);
@@ -28,7 +27,6 @@ CREATE TABLE public.credentials_in_status_list
     status_list_index          INTEGER                  NOT NULL,
 --  is revoked or suspended
     is_canceled                BOOLEAN                  NOT NULL default false,
-    is_processed               BOOLEAN                  NOT NULL default false,
     created_at                 TIMESTAMP WITH TIME ZONE NOT NULL default now(),
     updated_at                 TIMESTAMP WITH TIME ZONE NOT NULL default now(),
 

--- a/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V19__update_revocation_status_list_table_and_columns.sql
+++ b/pollux/lib/sql-doobie/src/main/resources/sql/pollux/V19__update_revocation_status_list_table_and_columns.sql
@@ -1,0 +1,11 @@
+ALTER TABLE public.credential_status_lists
+    DROP COLUMN encoded_list,
+    DROP COLUMN proof;
+
+ALTER TABLE public.credential_status_lists
+    ADD COLUMN status_list_credential JSON NOT NULL,
+    ADD COLUMN size INTEGER NOT NULL DEFAULT 131072,
+    ADD COLUMN last_used_index INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE public.credentials_in_status_list
+    ADD COLUMN is_processed BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
### Description: 

This PR undoes the edit of the migration that was introduced in https://github.com/hyperledger-labs/open-enterprise-agent/pull/934,  and instead creates a new migration that archives the same state in the DB. Essentially after introducing this change the state of the database will be the same as previously, but with this change, we are not editing migration that was already applied in the SIT environment, which will make the deployment easier.

P.S The tables that the second migration is editing (which were created by the first migration) will be empty 100%, so there is no need to worry about retaining data in this case.

### Alternatives Considered (optional): 
Alternatively, we can either clean the database on prod and re-run the migrations, or edit the table manually because migration V16 won't run again on prod, since it has already been applied.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-labs/open-enterprise-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
