### PR TITLE
feat(agent): add browser fingerprint label to http metrics

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/http/ZHttp4sBlazeServer.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/http/ZHttp4sBlazeServer.scala
@@ -68,11 +68,14 @@ class ZHttp4sBlazeServer(micrometerRegistry: PrometheusMeterRegistry, metricsNam
           case None       => "unknown"
         }
       },
-      "api_key" -> { case (_, sr) =>
-        sr.header("apikey").getOrElse("unknown")
+      "api_key_hash" -> { case (_, sr) =>
+        sr.header("apikey").map(x => Sha256Hash.compute(x.getBytes).hexEncoded).getOrElse("unknown")
       },
-      "token" -> { case (_, sr) =>
-        sr.header("authorization").map(_.split(" ").last).getOrElse("unknown")
+      "token_hash" -> { case (_, sr) =>
+        sr.header("authorization")
+          .map(_.split(" ").last)
+          .map(x => Sha256Hash.compute(x.getBytes).hexEncoded)
+          .getOrElse("unknown")
       },
     ),
   )


### PR DESCRIPTION
### Description: 
This PR adds a browser fingerprint label to HTTP metrics, as well as API key or bearer token if present from headers
<img width="1505" alt="image" src="https://github.com/hyperledger/identus-cloud-agent/assets/12943302/33b7c23d-6c3c-4c02-8e92-20807bfdb30a">


### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
