### PR TITLE
test: adds negative scenario outline for jwt credential offer

### DIFF
--- a/tests/integration-tests/src/test/kotlin/common/errors/CredentialOfferError.kt
+++ b/tests/integration-tests/src/test/kotlin/common/errors/CredentialOfferError.kt
@@ -1,23 +1,20 @@
 package common.errors
 
-import org.hyperledger.identus.client.models.Connection
 import org.hyperledger.identus.client.models.CreateIssueCredentialRecordRequest
 import java.util.UUID
 
 enum class CredentialOfferError {
     UNKNOWN_CONNECTION_ID {
-        override fun updateCredentialWithError(credentialOffer: CreateIssueCredentialRecordRequest): CreateIssueCredentialRecordRequest {
-            return CreateIssueCredentialRecordRequest(
-                schemaId = credentialOffer.schemaId,
-                claims = credentialOffer.claims,
-                issuingDID = credentialOffer.issuingDID,
-                issuingKid = credentialOffer.issuingKid,
-                connectionId = UUID.randomUUID(),
-                validityPeriod = credentialOffer.validityPeriod,
-                credentialFormat = credentialOffer.credentialFormat,
-                automaticIssuance = credentialOffer.automaticIssuance,
-            )
-        }
+        override fun updateCredentialWithError(credentialOffer: CreateIssueCredentialRecordRequest): CreateIssueCredentialRecordRequest = CreateIssueCredentialRecordRequest(
+            schemaId = credentialOffer.schemaId,
+            claims = credentialOffer.claims,
+            issuingDID = credentialOffer.issuingDID,
+            issuingKid = credentialOffer.issuingKid,
+            connectionId = UUID.randomUUID(),
+            validityPeriod = credentialOffer.validityPeriod,
+            credentialFormat = credentialOffer.credentialFormat,
+            automaticIssuance = credentialOffer.automaticIssuance,
+        )
     }, ;
 
     abstract fun updateCredentialWithError(credentialOffer: CreateIssueCredentialRecordRequest): CreateIssueCredentialRecordRequest

--- a/tests/integration-tests/src/test/kotlin/common/errors/CredentialOfferError.kt
+++ b/tests/integration-tests/src/test/kotlin/common/errors/CredentialOfferError.kt
@@ -1,0 +1,24 @@
+package common.errors
+
+import org.hyperledger.identus.client.models.Connection
+import org.hyperledger.identus.client.models.CreateIssueCredentialRecordRequest
+import java.util.UUID
+
+enum class CredentialOfferError {
+    UNKNOWN_CONNECTION_ID {
+        override fun updateCredentialWithError(credentialOffer: CreateIssueCredentialRecordRequest): CreateIssueCredentialRecordRequest {
+            return CreateIssueCredentialRecordRequest(
+                schemaId = credentialOffer.schemaId,
+                claims = credentialOffer.claims,
+                issuingDID = credentialOffer.issuingDID,
+                issuingKid = credentialOffer.issuingKid,
+                connectionId = UUID.randomUUID(),
+                validityPeriod = credentialOffer.validityPeriod,
+                credentialFormat = credentialOffer.credentialFormat,
+                automaticIssuance = credentialOffer.automaticIssuance,
+            )
+        }
+    }, ;
+
+    abstract fun updateCredentialWithError(credentialOffer: CreateIssueCredentialRecordRequest): CreateIssueCredentialRecordRequest
+}

--- a/tests/integration-tests/src/test/kotlin/common/errors/JwtCredentialError.kt
+++ b/tests/integration-tests/src/test/kotlin/common/errors/JwtCredentialError.kt
@@ -1,12 +1,13 @@
-package common
+package common.errors
 
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
+import common.VerifiableJwt
 import models.JwtCredential
 import org.hyperledger.identus.client.models.VcVerification
 import java.time.OffsetDateTime
 
-enum class JwtCredentialProblem {
+enum class JwtCredentialError {
     ALGORITHM_VERIFICATION {
         override fun jwt(): String {
             val jwt = VerifiableJwt.jwtVCv1()
@@ -104,7 +105,7 @@ enum class JwtCredentialProblem {
             // cases since it's not possible to inherit final class
             VcVerification.entries.forEach {
                 try {
-                    JwtCredentialProblem.valueOf(it.name)
+                    JwtCredentialError.valueOf(it.name)
                 } catch (e: IllegalArgumentException) {
                     throw IllegalArgumentException("JwtCredentialProblem does not contain the new ${it.name} VcVerification case")
                 }

--- a/tests/integration-tests/src/test/kotlin/common/errors/SchemaTemplateError.kt
+++ b/tests/integration-tests/src/test/kotlin/common/errors/SchemaTemplateError.kt
@@ -1,11 +1,11 @@
-package common
+package common.errors
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import common.CredentialSchema.STUDENT_SCHEMA
 import net.serenitybdd.screenplay.Actor
 
-enum class SchemaErrorTemplate {
+enum class SchemaTemplateError {
     TYPE_AND_PROPERTIES_WITHOUT_SCHEMA_TYPE {
         override fun innerSchema(): String = """
                 {

--- a/tests/integration-tests/src/test/kotlin/steps/common/CommonSteps.kt
+++ b/tests/integration-tests/src/test/kotlin/steps/common/CommonSteps.kt
@@ -4,6 +4,7 @@ import common.CredentialSchema
 import common.DidType
 import interactions.Get
 import io.cucumber.java.en.Given
+import io.cucumber.java.en.Then
 import io.iohk.atala.automation.extensions.get
 import io.iohk.atala.automation.serenity.ensure.Ensure
 import net.serenitybdd.rest.SerenityRest
@@ -125,5 +126,12 @@ class CommonSteps {
             connectionSteps.inviteeReceivesTheConnectionResponse(invitee)
             connectionSteps.inviterAndInviteeHaveAConnection(inviter, invitee)
         }
+    }
+
+    @Then("{actor} should see the status code was {int}")
+    fun actorShouldSeeHttpStatusWasExpected(actor: Actor, statusCode: Int) {
+        actor.attemptsTo(
+            Ensure.thatTheLastResponse().statusCode().isEqualTo(statusCode),
+        )
     }
 }

--- a/tests/integration-tests/src/test/kotlin/steps/credentials/JwtCredentialSteps.kt
+++ b/tests/integration-tests/src/test/kotlin/steps/credentials/JwtCredentialSteps.kt
@@ -134,7 +134,7 @@ class JwtCredentialSteps {
     fun issuerIssuesTheJwtCredentialWithIssue(
         issuer: Actor,
         holder: Actor,
-        credentialOfferError: CredentialOfferError
+        credentialOfferError: CredentialOfferError,
     ) {
         val credentialOfferRequest = CreateIssueCredentialRecordRequest(
             claims = linkedMapOf(

--- a/tests/integration-tests/src/test/kotlin/steps/credentials/JwtCredentialSteps.kt
+++ b/tests/integration-tests/src/test/kotlin/steps/credentials/JwtCredentialSteps.kt
@@ -1,6 +1,7 @@
 package steps.credentials
 
 import common.CredentialSchema
+import common.errors.CredentialOfferError
 import interactions.Post
 import interactions.body
 import io.cucumber.java.en.When
@@ -10,7 +11,10 @@ import net.serenitybdd.rest.SerenityRest
 import net.serenitybdd.screenplay.Actor
 import org.apache.http.HttpStatus.SC_CREATED
 import org.apache.http.HttpStatus.SC_OK
-import org.hyperledger.identus.client.models.*
+import org.hyperledger.identus.client.models.AcceptCredentialOfferRequest
+import org.hyperledger.identus.client.models.Connection
+import org.hyperledger.identus.client.models.CreateIssueCredentialRecordRequest
+import org.hyperledger.identus.client.models.IssueCredentialRecord
 
 class JwtCredentialSteps {
 
@@ -123,6 +127,32 @@ class JwtCredentialSteps {
         holder.attemptsTo(
             Post.to("/issue-credentials/records/$recordId/accept-offer").body(acceptRequest),
             Ensure.thatTheLastResponse().statusCode().isEqualTo(SC_OK),
+        )
+    }
+
+    @When("{actor} offers a jwt credential to {actor} with {} issue")
+    fun issuerIssuesTheJwtCredentialWithIssue(
+        issuer: Actor,
+        holder: Actor,
+        credentialOfferError: CredentialOfferError
+    ) {
+        val credentialOfferRequest = CreateIssueCredentialRecordRequest(
+            claims = linkedMapOf(
+                "name" to "Name",
+                "surname" to "Surname",
+            ),
+            issuingDID = issuer.recall("shortFormDid"),
+            issuingKid = "assertion-1",
+            connectionId = issuer.recall<Connection>("connection-with-${holder.name}").connectionId,
+            validityPeriod = 3600.0,
+            credentialFormat = "JWT",
+            automaticIssuance = false,
+        )
+
+        val credentialOfferRequestError = credentialOfferError.updateCredentialWithError(credentialOfferRequest)
+
+        issuer.attemptsTo(
+            Post.to("/issue-credentials/credential-offers").body(credentialOfferRequestError),
         )
     }
 }

--- a/tests/integration-tests/src/test/kotlin/steps/schemas/CredentialSchemasSteps.kt
+++ b/tests/integration-tests/src/test/kotlin/steps/schemas/CredentialSchemasSteps.kt
@@ -2,6 +2,7 @@ package steps.schemas
 
 import common.*
 import common.CredentialSchema.STUDENT_SCHEMA
+import common.errors.SchemaTemplateError
 import interactions.*
 import io.cucumber.java.en.*
 import io.iohk.atala.automation.extensions.get
@@ -35,7 +36,7 @@ class CredentialSchemasSteps {
     }
 
     @When("{actor} creates a schema containing '{}' issue")
-    fun agentCreatesASchemaContainingIssue(actor: Actor, schema: SchemaErrorTemplate) {
+    fun agentCreatesASchemaContainingIssue(actor: Actor, schema: SchemaTemplateError) {
         actor.attemptsTo(Post.to("/schema-registry/schemas").body(schema.schema(actor)))
     }
 

--- a/tests/integration-tests/src/test/kotlin/steps/verification/VcVerificationSteps.kt
+++ b/tests/integration-tests/src/test/kotlin/steps/verification/VcVerificationSteps.kt
@@ -3,6 +3,7 @@ package steps.verification
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import common.*
+import common.errors.JwtCredentialError
 import interactions.Post
 import interactions.body
 import io.cucumber.datatable.DataTable
@@ -48,7 +49,7 @@ class VcVerificationSteps {
     }
 
     @Given("{actor} has a '{}' problem in the Verifiable Credential")
-    fun holderHasProblemInTheVerifiableCredential(holder: Actor, problem: JwtCredentialProblem) {
+    fun holderHasProblemInTheVerifiableCredential(holder: Actor, problem: JwtCredentialError) {
         val jwt = problem.jwt()
         holder.remember("jwt", jwt)
         holder.remember("issuerDid", "did:prism:issuer")
@@ -65,7 +66,7 @@ class VcVerificationSteps {
     }
 
     @Then("{actor} should see that verification has failed with '{}' problem")
-    fun holderShouldSeeThatVerificationHasFailedWithProblem(holder: Actor, problem: JwtCredentialProblem) {
+    fun holderShouldSeeThatVerificationHasFailedWithProblem(holder: Actor, problem: JwtCredentialError) {
     }
 
     @Then("{actor} should see that all checks have passed")

--- a/tests/integration-tests/src/test/resources/features/credential/jwt/issuance.feature
+++ b/tests/integration-tests/src/test/resources/features/credential/jwt/issuance.feature
@@ -14,12 +14,6 @@ Feature: Issue JWT credential
     And Holder accepts jwt credential offer using 'auth-1' key id
     And Issuer issues the credential
     Then Holder receives the issued credential
-    When Issuer revokes the credential issued to Holder
-    Then Issuer should see the credential was revoked
-    When Issuer sends a request for jwt proof presentation to Holder
-    And Holder receives the presentation proof request
-    And Holder makes the jwt presentation of the proof
-    Then Issuer sees the proof returned verification failed
     Examples:
       | assertionMethod | assertionName |
       | secp256k1       | assert-1      |
@@ -64,3 +58,13 @@ Feature: Issue JWT credential
     And Holder accepts jwt credential offer using 'auth-1' key id
     And Issuer issues the credential
     Then Holder receives the issued credential
+
+  Scenario Outline: Issuing a credential with <issue> issuer should return <httpStatus>
+    Given Issuer and Holder have an existing connection
+    And Issuer has a published DID for JWT
+    And Holder has an unpublished DID for JWT
+    When Issuer offers a jwt credential to Holder with <issue> issue
+    Then Issuer should see the status code was <httpStatus>
+    Examples:
+      | issue                 | httpStatus |
+      | UNKNOWN_CONNECTION_ID | 404        |

--- a/tests/integration-tests/src/test/resources/features/credential/jwt/issuance.feature
+++ b/tests/integration-tests/src/test/resources/features/credential/jwt/issuance.feature
@@ -61,8 +61,8 @@ Feature: Issue JWT credential
 
   Scenario Outline: Issuing a credential with <issue> issuer should return <httpStatus>
     Given Issuer and Holder have an existing connection
-    And Issuer has a published DID for JWT
-    And Holder has an unpublished DID for JWT
+    And Issuer has a published DID for 'JWT'
+    And Holder has an unpublished DID for 'JWT'
     When Issuer offers a jwt credential to Holder with <issue> issue
     Then Issuer should see the status code was <httpStatus>
     Examples:


### PR DESCRIPTION
### Description: 
Adds negative scenario outline for jwt credential offer

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger/identus-cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
