### PR TITLE
docs: refactor links from `docs` to `home`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All documentation, tutorials and API references for the Identus ecosystem can be
 
 Before starting to use the Cloud Agent, it is important to understand the basic concepts of self-sovereign identity (SSI). The following resources provide a good introduction to SSI:
 
-* [Identus SSI introduction](https://hyperledger.github.io/identus-docs/docs/category/concepts)
+* [Identus SSI introduction](https://hyperledger-identus.github.io/docs/home/category/concepts)
 * [Linux Foundation Course: Getting Started with SSI](https://www.edx.org/learn/computer-programming/the-linux-foundation-getting-started-with-self-sovereign-identity)
 
 ### Architecture

--- a/docs/docusaurus/connections/connection.md
+++ b/docs/docusaurus/connections/connection.md
@@ -2,15 +2,15 @@
 
 A connection is a stateful relationship between two parties that enables secure communication.
 
-The [Connection protocol](/docs/concepts/glossary#connection-protocol) is required to establish secure connections between agents,
+The [Connection protocol](/home/concepts/glossary#connection-protocol) is required to establish secure connections between agents,
 allowing them to exchange information and interact.
 
 ## Roles
 
 The connection protocol has two roles:
 
-1. [Inviter](/docs/concepts/glossary#inviter): A subject that initiates a connection request by sending a [connection invitation](/docs/concepts/glossary#connection-invitation).
-2. [Invitee](/docs/concepts/glossary#invitee): A subject that receives a connection invitation and accepts it by sending a [connection request](/docs/concepts/glossary#connection-request).
+1. [Inviter](/home/concepts/glossary#inviter): A subject that initiates a connection request by sending a [connection invitation](/home/concepts/glossary#connection-invitation).
+2. [Invitee](/home/concepts/glossary#invitee): A subject that receives a connection invitation and accepts it by sending a [connection request](/home/concepts/glossary#connection-request).
 
 ## Prerequisites
 
@@ -55,7 +55,7 @@ ConnectionResponseSent --> [*]
 
 1. Receive the OOB invitation (`InvitationReceived` state)
 2. Accept the invitation (connection is created in `ConnectionRequestPending` state)
-3. Send the connection request via [DIDComm](/docs/concepts/glossary#didcomm) (connection achieves `ConnectionRequestSent` state)
+3. Send the connection request via [DIDComm](/home/concepts/glossary#didcomm) (connection achieves `ConnectionRequestSent` state)
 4. Receive the connection response (connection achieves `ConnectionResponseReceived` state)
 
 The following diagram represents the Invitee's Connection state transitions:

--- a/docs/docusaurus/credentialdefinition/create.md
+++ b/docs/docusaurus/credentialdefinition/create.md
@@ -1,6 +1,6 @@
 # Create the Credential Definition
 
-The Cloud Agent exposes REST API for creation, fetching, and searching the [credential definition](/docs/concepts/glossary#credential-definition) records.
+The Cloud Agent exposes REST API for creation, fetching, and searching the [credential definition](/home/concepts/glossary#credential-definition) records.
 
 The OpenAPI specification and ReDoc documentation describe the endpoint.
 
@@ -39,7 +39,7 @@ Here's a sample content of the credential definition:
 
 2. In your API client, initiate a new POST request to either `/credential-definition-registry/definitions` or `/credential-definition-registry/definitions/did-url`  endpoints. They both take the same payload
     1. `/credential-definition-registry/definitions` creates a credential definition that can later be resolved via HTTP URL
-    2. `/credential-definition-registry/definitions/did-url` creates a credential definition that can later be resolved via [DID URL](/docs/concepts/glossary#did-url), the DID includes a service endpoint with the location of the credential definition registry.
+    2. `/credential-definition-registry/definitions/did-url` creates a credential definition that can later be resolved via [DID URL](/home/concepts/glossary#did-url), the DID includes a service endpoint with the location of the credential definition registry.
 
 Please note: The `author` field value should align with the short form of a PRISM DID previously created by the same agent. It's okay if this DID is unpublished. You can refer to the [Create DID](../dids/create.md) documentation for more comprehensive details on crafting a PRISM DID.
 
@@ -148,7 +148,7 @@ You should receive a response containing the JSON object representing the creden
 }
 ```
 
-Or in case of DID URL, the respoinse is [Prism Envelope](/docs/concepts/glossary#prism-envelope)
+Or in case of DID URL, the respoinse is [Prism Envelope](/home/concepts/glossary#prism-envelope)
 
 ```json
 {

--- a/docs/docusaurus/credentialdefinition/delete.md
+++ b/docs/docusaurus/credentialdefinition/delete.md
@@ -1,6 +1,6 @@
 # Delete the Credential Definition
 
-Unfortunately, once published (especially in the [Verifiable Data Registry (VDR)](/docs/concepts/glossary#verifiable-data-registry), deleting the credential definition becomes unfeasible.
+Unfortunately, once published (especially in the [Verifiable Data Registry (VDR)](/home/concepts/glossary#verifiable-data-registry), deleting the credential definition becomes unfeasible.
 
 In the Identus Platform, credential definitions aren't published to the VDR. This functionality will be incorporated in subsequent versions of the platform. Hence, the platform currently doesn't provide a REST API for deletion.
 

--- a/docs/docusaurus/credentials/connectionless/issue.md
+++ b/docs/docusaurus/credentials/connectionless/issue.md
@@ -3,14 +3,14 @@ import TabItem from '@theme/TabItem';
 
 # Issue credentials (Connectionless)
 
-In the Identus Platform, the [Issue Credentials Protocol](/docs/concepts/glossary#issue-credential-protocol) allows you to create, retrieve, and manage issued [verifiable credentials (VCs)](/docs/concepts/glossary#verifiable-credentials) between a VC issuer and a VC holder.
+In the Identus Platform, the [Issue Credentials Protocol](/home/concepts/glossary#issue-credential-protocol) allows you to create, retrieve, and manage issued [verifiable credentials (VCs)](/home/concepts/glossary#verifiable-credentials) between a VC issuer and a VC holder.
 
 ## Roles
 
 In the Issue Credentials Protocol, there are two roles:
 
-1. The [Issuer](/docs/concepts/glossary#issuer) is responsible for creating a new credential offer, sending it to a Holder, and issuing the VC once the offer is accepted.
-2. The [Holder](/docs/concepts/glossary#holder) is responsible for accepting a credential offer from an issuer and receiving the VC.
+1. The [Issuer](/home/concepts/glossary#issuer) is responsible for creating a new credential offer, sending it to a Holder, and issuing the VC once the offer is accepted.
+2. The [Holder](/home/concepts/glossary#holder) is responsible for accepting a credential offer from an issuer and receiving the VC.
 
 The Issuer and Holder interact with the Identus Cloud Agent API to perform the operations defined in the protocol.
 
@@ -23,14 +23,14 @@ Before using the "Connectionless" Issuing Credentials protocol, the following co
 <TabItem value="jwt" label="JWT">
 
 1. Issuer Cloud Agents is up and running
-2. The Issuer has a published PRISM DID, and the [DID document](/docs/concepts/glossary#did-document) must have at least one `assertionMethod` key for issuing credentials (see [Create DID](../../dids/create.md) and [Publish DID](../../dids/publish.md))
+2. The Issuer has a published PRISM DID, and the [DID document](/home/concepts/glossary#did-document) must have at least one `assertionMethod` key for issuing credentials (see [Create DID](../../dids/create.md) and [Publish DID](../../dids/publish.md))
 3. The Holder is either another Cloud Agent or Edge Agent SDK
 
 </TabItem>
 <TabItem value="anoncreds" label="AnonCreds">
 
 1. Issuer Cloud Agents is up and running
-2. The Issuer has a published PRISM DID, and the [DID document](/docs/concepts/glossary#did-document) must have at least one `assertionMethod` key for issuing credentials (see [Create DID](../../dids/create.md) and [Publish DID](../../dids/publish.md))
+2. The Issuer has a published PRISM DID, and the [DID document](/home/concepts/glossary#did-document) must have at least one `assertionMethod` key for issuing credentials (see [Create DID](../../dids/create.md) and [Publish DID](../../dids/publish.md))
 3. The Issuer must have created an AnonCreds Credential Definition as described [here](../../credentialdefinition/create.md).
 4. The Holder is either another Cloud Agent or Edge Agent SDK
 
@@ -39,7 +39,7 @@ Before using the "Connectionless" Issuing Credentials protocol, the following co
 
 - 📌 **Note:** Currently we only support `Ed25519` curve
 1. Issuer Cloud Agents is up and running
-2. The Issuer has a published PRISM DID, and the [DID document](/docs/concepts/glossary#did-document) must have at least one `assertionMethod` key for issuing credentials (see [Create DID](../../dids/create.md) and [Publish DID](../../dids/publish.md))
+2. The Issuer has a published PRISM DID, and the [DID document](/home/concepts/glossary#did-document) must have at least one `assertionMethod` key for issuing credentials (see [Create DID](../../dids/create.md) and [Publish DID](../../dids/publish.md))
 3. The Holder is either another Cloud Agent or Edge Agent SDK
 4. The Holder must have a PRISM DID, and the DID document must have at least one `authentication` key for presenting the proof and the curve must be `Ed25519`.
 
@@ -52,7 +52,7 @@ The protocol described is a VC issuance process between an Issuer (Identus Cloud
 
 The protocol consists of the following main parts:
 
-1. The Issuer creates a new credential offer using the [`/issue-credentials/credential-offers/invitation`](/identus-docs/agent-api/#tag/Issue-Credentials-Protocol/operation/createCredentialOffer) endpoint, which includes information such as the schema identifier and claims. This returns a unique OOB (out-of-band) invitate code for the prospective Holder.
+1. The Issuer creates a new credential offer using the [`/issue-credentials/credential-offers/invitation`](/docs/agent-api/#tag/Issue-Credentials-Protocol/operation/createCredentialOffer) endpoint, which includes information such as the schema identifier and claims. This returns a unique OOB (out-of-band) invitate code for the prospective Holder.
 2. The Holder accepts the OOB invite (see SDK `acceptInvitation`)
 3. The Issuer responds by sending the actual Credential Offer
 4. The Holder accepts the Credential Offer
@@ -285,7 +285,7 @@ To accept the offer, the Holder can make a `POST` request to the [`/issue-creden
 <TabItem value="jwt" label="JWT">
 
 1. `holder_record_id`: The unique identifier of the issue credential record known by the holder's Cloud Agent.
-2. `subjectId`: This field represents the unique identifier for the subject of the verifiable credential. It is a short-form PRISM [DID](/docs/concepts/glossary#decentralized-identifier) string, such as `did:prism:subjectIdentifier`.
+2. `subjectId`: This field represents the unique identifier for the subject of the verifiable credential. It is a short-form PRISM [DID](/home/concepts/glossary#decentralized-identifier) string, such as `did:prism:subjectIdentifier`.
 
 ```shell
 # Holder POST request to accept the credential offer
@@ -317,7 +317,7 @@ curl -X POST "http://localhost:8090/cloud-agent/issue-credentials/records/$holde
 <TabItem value="sdjwt" label="SDJWT">
 
 1. `holder_record_id`: The unique identifier of the issue credential record known by the holder's Cloud Agent.
-2. `subjectId`: This field represents the unique identifier for the subject of the verifiable credential. It is a short-form PRISM [DID](/docs/concepts/glossary#decentralized-identifier) string, such as `did:prism:subjectIdentifier`.
+2. `subjectId`: This field represents the unique identifier for the subject of the verifiable credential. It is a short-form PRISM [DID](/home/concepts/glossary#decentralized-identifier) string, such as `did:prism:subjectIdentifier`.
 3. `keyId` Option parameter
    1. when keyId is not provided the SDJWT VC is not binded to Holder/Prover key
    ```shell

--- a/docs/docusaurus/credentials/didcomm/issue.md
+++ b/docs/docusaurus/credentials/didcomm/issue.md
@@ -3,17 +3,17 @@ import TabItem from '@theme/TabItem';
 
 # Issue credentials (DIDComm)
 
-In the Identus Platform, the [Issue Credentials Protocol](/docs/concepts/glossary#issue-credential-protocol) allows you
-to create, retrieve, and manage issued [verifiable credentials (VCs)](/docs/concepts/glossary#verifiable-credentials)
+In the Identus Platform, the [Issue Credentials Protocol](/home/concepts/glossary#issue-credential-protocol) allows you
+to create, retrieve, and manage issued [verifiable credentials (VCs)](/home/concepts/glossary#verifiable-credentials)
 between a VC issuer and a VC holder.
 
 ## Roles
 
 In the Issue Credentials Protocol, there are two roles:
 
-1. The [Issuer](/docs/concepts/glossary#issuer) is responsible for creating a new credential offer, sending it to a
+1. The [Issuer](/home/concepts/glossary#issuer) is responsible for creating a new credential offer, sending it to a
    Holder, and issuing the VC once the offer is accepted.
-2. The [Holder](/docs/concepts/glossary#holder) is responsible for accepting a credential offer from an issuer and
+2. The [Holder](/home/concepts/glossary#holder) is responsible for accepting a credential offer from an issuer and
    receiving the VC.
 
 The Issuer and Holder interact with the Identus Cloud Agent API to perform the operations defined in the protocol.
@@ -28,7 +28,7 @@ Before using the Issuing Credentials protocol, the following conditions must be 
 1. Issuer and Holder Cloud Agents up and running
 2. A connection must be established between the Issuer and Holder Cloud Agents (
    see [Connections](../../connections/connection.md))
-3. The Issuer must have a published PRISM DID, and the [DID document](/docs/concepts/glossary#did-document) must have at
+3. The Issuer must have a published PRISM DID, and the [DID document](/home/concepts/glossary#did-document) must have at
    least one `assertionMethod` key for issuing credentials (see [Create DID](../../dids/create.md)
    and [Publish DID](../../dids/publish.md))
 4. The Issuer must have created a VC schema as described [here](../../schemas/create.md).
@@ -52,7 +52,7 @@ Before using the Issuing Credentials protocol, the following conditions must be 
 1. Issuer and Holder Cloud Agents up and running
 2. A connection must be established between the Issuer and Holder Cloud Agents (
    see [Connections](../../connections/connection.md))
-3. The Issuer must have a published PRISM DID, and the [DID document](/docs/concepts/glossary#did-document) must have at
+3. The Issuer must have a published PRISM DID, and the [DID document](/home/concepts/glossary#did-document) must have at
    least one `assertionMethod` key for issuing credentials and the curve must be `Ed25519` (
    see [Create DID](../../dids/create.md) and [Publish DID](../../dids/publish.md))
 4. The Issuer must have created a VC schema as described [here](../../schemas/create.md).
@@ -78,7 +78,7 @@ The protocol consists of the following main parts:
    endpoint.
 3. The Issuer then uses
    the [`/issue-credentials/records/{recordId}/issue-credential`](/agent-api/#tag/Issue-Credentials-Protocol/operation/issueCredential)
-   endpoint to issue the credential, which gets sent to the Holder via [DIDComm](/docs/concepts/glossary#didcomm). The
+   endpoint to issue the credential, which gets sent to the Holder via [DIDComm](/home/concepts/glossary#didcomm). The
    Holder receives the credential, and the protocol is complete.
 
 The claims provide specific information about the individual, such as their name or qualifications.
@@ -457,7 +457,7 @@ endpoint with a JSON payload that includes the following information:
 
 1. `holder_record_id`: The unique identifier of the issue credential record known by the holder's Cloud Agent.
 2. `subjectId`: This field represents the unique identifier for the subject of the verifiable credential. It is a
-   short-form PRISM [DID](/docs/concepts/glossary#decentralized-identifier) string, such
+   short-form PRISM [DID](/home/concepts/glossary#decentralized-identifier) string, such
    as `did:prism:subjectIdentifier`.
 
 ```shell
@@ -491,7 +491,7 @@ curl -X POST "http://localhost:8090/cloud-agent/issue-credentials/records/$holde
 
 1. `holder_record_id`: The unique identifier of the issue credential record known by the holder's Cloud Agent.
 2. `subjectId`: This field represents the unique identifier for the subject of the verifiable credential. It is a
-   short-form PRISM [DID](/docs/concepts/glossary#decentralized-identifier) string, such
+   short-form PRISM [DID](/home/concepts/glossary#decentralized-identifier) string, such
    as `did:prism:subjectIdentifier`.
 3. `keyId` Option parameter
     1. when keyId is not provided the SDJWT VC is not binded to Holder/Prover key

--- a/docs/docusaurus/credentials/didcomm/present-proof.md
+++ b/docs/docusaurus/credentials/didcomm/present-proof.md
@@ -3,9 +3,9 @@ import TabItem from '@theme/TabItem';
 
 # Present proof (DIDComm)
 
-The [Present Proof Protocol](/docs/concepts/glossary#present-proof-protocol) allows:
-- a [Verifier](/docs/concepts/glossary#verifier) to request a verifiable credential presentation from a Holder/Prover
-- a [Holder/Prover](/docs/concepts/glossary#holder) responds by presenting a cryptographic proof to the Verifier
+The [Present Proof Protocol](/home/concepts/glossary#present-proof-protocol) allows:
+- a [Verifier](/home/concepts/glossary#verifier) to request a verifiable credential presentation from a Holder/Prover
+- a [Holder/Prover](/home/concepts/glossary#holder) responds by presenting a cryptographic proof to the Verifier
 
 The protocol provides endpoints for a Verifier to request new proof presentations from Holder/Provers and for a Holder/Prover to respond to the presentation request using a specific verifiable credential they own.
 
@@ -14,7 +14,7 @@ The protocol provides endpoints for a Verifier to request new proof presentation
 The present proof protocol has two roles:
 
 1. Verifier: A subject requesting a proof presentation by sending a request presentation message, then verifying the presentation.
-2. Holder/Prover: A [subject](/docs/concepts/glossary#subject) that receives a [proof presentation](/docs/concepts/glossary#proof-presentation) request, prepares a proof, and sends it to the verifier by sending a proof presentation message.
+2. Holder/Prover: A [subject](/home/concepts/glossary#subject) that receives a [proof presentation](/home/concepts/glossary#proof-presentation) request, prepares a proof, and sends it to the verifier by sending a proof presentation message.
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ Before using the Proof Presentation protocol, the following conditions must be p
 
 1. Holder/Prover and Verifier Cloud Agents must be up and running
 2. A connection must be established between the Holder/Prover and Verifier Cloud Agents (see [Connections](../../connections/connection.md))
-3. The Holder/Prover should hold a [verifiable credential (VC)](/docs/concepts/glossary#verifiable-credential) received from an [Issuer](/docs/concepts/glossary#issuer) see [Issue](./issue.md).
+3. The Holder/Prover should hold a [verifiable credential (VC)](/home/concepts/glossary#verifiable-credential) received from an [Issuer](/home/concepts/glossary#issuer) see [Issue](./issue.md).
 
 ## Overview
 

--- a/docs/docusaurus/credentials/oid4vci/issue.md
+++ b/docs/docusaurus/credentials/oid4vci/issue.md
@@ -1,6 +1,6 @@
 # Issue credentials (OID4VCI)
 
-[OID4VCI](/docs/concepts/glossary#oid4vci) (OpenID for Verifiable Credential Issuance) is a protocol that extends OAuth2 to issue credentials.
+[OID4VCI](/home/concepts/glossary#oid4vci) (OpenID for Verifiable Credential Issuance) is a protocol that extends OAuth2 to issue credentials.
 It involves a Credential Issuer server and an Authorization server working together,
 using the authorization and token endpoints on the Authorization Server to grant holders access to credentials on the Credential Issuer server.
 These servers may or may not be the same, depending on the implementation.

--- a/docs/docusaurus/dids/create.md
+++ b/docs/docusaurus/dids/create.md
@@ -1,16 +1,16 @@
 # Create DID
 
-PRISM DIDs are a type of [decentralized identifier (DID)](/docs/concepts/glossary#decentralized-identifier) used across the Atala PRISM product suite.
+PRISM DIDs are a type of [decentralized identifier (DID)](/home/concepts/glossary#decentralized-identifier) used across the Atala PRISM product suite.
 
-It is a variation of a [sidetree protocol](https://identity.foundation/sidetree/spec/) and uses the Cardano blockchain as the underlying ledger for [DID resolution](/docs/concepts/glossary#did-resolution) and operation publication.
+It is a variation of a [sidetree protocol](https://identity.foundation/sidetree/spec/) and uses the Cardano blockchain as the underlying ledger for [DID resolution](/home/concepts/glossary#did-resolution) and operation publication.
 Please refer to the [PRISM method specification](https://github.com/input-output-hk/prism-did-method-spec/blob/main/w3c-spec/PRISM-method.md) for a more detailed explanation of how it works.
 
-PRISM DIDs can be created entirely offline without interacting with the blockchain by constructing a DID create-operation, a [protocol buffer (protobuf)](/docs/concepts/glossary#protocol-buffer) message with a set of public keys and services.
+PRISM DIDs can be created entirely offline without interacting with the blockchain by constructing a DID create-operation, a [protocol buffer (protobuf)](/home/concepts/glossary#protocol-buffer) message with a set of public keys and services.
 Once the create-operation gets constructed, deriving a DID from this operation is possible, which is well-defined by the [PRISM DID method](https://github.com/input-output-hk/prism-did-method-spec/blob/main/w3c-spec/PRISM-method.md).
 
 ## Roles
 
-1. [DID Controller](/docs/concepts/glossary#did-controller) is the organization or individual who has control of the DID.
+1. [DID Controller](/home/concepts/glossary#did-controller) is the organization or individual who has control of the DID.
 
 ## Prerequisites
 
@@ -53,7 +53,7 @@ The result should show an empty list, as no DIDs exist on this Cloud Agent insta
 
 ### 2. Create the Cloud Agent managed DID using DID registrar endpoint
 
-The DID controller can create a new DID by sending a [DID document](/docs/concepts/glossary#did-document) template to the Agent.
+The DID controller can create a new DID by sending a [DID document](/home/concepts/glossary#did-document) template to the Agent.
 Since key pairs are generated and managed by the Cloud Agent, DID controller only has to specify the key `id`,
 `purpose` (`authentication`, `assertionMethod`, etc.), and optional `curve` (`secp256k1`, `Ed25519`, `X25519`).
 If the `curve` is omitted, the agent uses the `secp256k1` curve by default.

--- a/docs/docusaurus/dids/deactivate.md
+++ b/docs/docusaurus/dids/deactivate.md
@@ -1,7 +1,7 @@
 # Deactivate DID
 
 DID deactivation is an important feature that provides greater control for managing digital identity.
-DID deactivation can be helpful if the [DID](/docs/concepts/glossary#decentralized-identifier) is compromised or unused.
+DID deactivation can be helpful if the [DID](/home/concepts/glossary#decentralized-identifier) is compromised or unused.
 This feature is crucial for the security and risk management of identity owners.
 
 Similar to [DID update](./update.md), deactivating a PRISM DID is a process of putting deactivate-operation on the blockchain so that other participants know that the DID is no longer active.
@@ -20,7 +20,7 @@ The PRISM DID method only allows published DID to be deactivated.
 ## Overview
 
 DID deactivation operates similarly to the DID update, where deactivate-operation publishes to the blockchain, and confirmation blocks must be created before participants consider it deactivated.
-Once the DID is deactivated, all content in the [DID document](/docs/concepts/glossary#did-document) gets deleted, and no operation will affect the DID afterward.
+Once the DID is deactivated, all content in the [DID document](/home/concepts/glossary#did-document) gets deleted, and no operation will affect the DID afterward.
 The same concept also holds for PRISM DID deactivation in that the fork can occur if any subsequent operation occurs before the operation is confirmed.
 Please refer to the `SECURE_DEPTH` parameter in [PRISM method - protocol parameters](https://github.com/input-output-hk/prism-did-method-spec/blob/main/w3c-spec/PRISM-method.md#versioning-and-protocol-parameters) for the number of confirmation blocks.
 At the time of writing, this number is 112 blocks.

--- a/docs/docusaurus/dids/publish.md
+++ b/docs/docusaurus/dids/publish.md
@@ -1,7 +1,7 @@
 # Publish DID
 
 PRISM DID creation involves generating key pairs and additional data (e.g., services) to construct a create-operation.
-The create-operation allows [DID Controller](/docs/concepts/glossary#did-controller) to derive two types of [DIDs](/docs/concepts/glossary#decentralized-identifiers):
+The create-operation allows [DID Controller](/home/concepts/glossary#did-controller) to derive two types of [DIDs](/home/concepts/glossary#decentralized-identifiers):
 
 1. [Long-form DID](https://github.com/input-output-hk/prism-did-method-spec/blob/main/w3c-spec/PRISM-method.md#long-form-dids-unpublished-dids). It has the following format `did:prism:<initial-hash>:<encoded-state>`
 2. Short-form DID. It has the following format `did:prism:<initial-hash>`
@@ -117,7 +117,7 @@ Example response with status `PUBLISHED`
 }
 ```
 
-> **Note:** The `status` here is the internal status of the DID on the Cloud Agent (`PUBLISHED`, `CREATED`, `PUBLICAION_PENDING`). It does not indicate the lifecycle of the DID observed on the blockchain (e.g., deactivated, etc.). The [DID resolution](/docs/concepts/glossary#did-resolution) metadata is for that purpose.
+> **Note:** The `status` here is the internal status of the DID on the Cloud Agent (`PUBLISHED`, `CREATED`, `PUBLICAION_PENDING`). It does not indicate the lifecycle of the DID observed on the blockchain (e.g., deactivated, etc.). The [DID resolution](/home/concepts/glossary#did-resolution) metadata is for that purpose.
 
 ### 4. Resolve a short-form DID
 

--- a/docs/docusaurus/dids/update.md
+++ b/docs/docusaurus/dids/update.md
@@ -1,11 +1,11 @@
 # Update DID
 
-PRISM DID method allows [DID Controller](/docs/concepts/glossary#did-controller) to update the content of the [DID document](/docs/concepts/glossary#did-document) by constructing a DID update-operation.
+PRISM DID method allows [DID Controller](/home/concepts/glossary#did-controller) to update the content of the [DID document](/home/concepts/glossary#did-document) by constructing a DID update-operation.
 The update-operation describes the update action on the DID document.
 For example, DID Controller can add a new key to the DID document by constructing an update-operation containing the `AddKeyAction`.
 It is also possible for DID Controller to compose multiple actions in the same update-operation.
 The [PRISM DID method - Update DID section](https://github.com/input-output-hk/prism-did-method-spec/blob/main/w3c-spec/PRISM-method.md#update-did) includes a complete list of supported update actions.
-The PRISM DID method only allows published [DID](/docs/concepts/glossary#decentralized-identifier) to be updated.
+The PRISM DID method only allows published [DID](/home/concepts/glossary#decentralized-identifier) to be updated.
 
 When updating a DID, each operation is connected through cryptography,
 forming a sequence of operations known as the lineage.

--- a/docs/docusaurus/index.md
+++ b/docs/docusaurus/index.md
@@ -3,9 +3,9 @@
 Welcome to the Identus Platform Tutorials!
 
 These tutorials will help you get started with using Identus Platform.
-The tutorials will guide you through setting up a connection, working with [Decentralized Identifiers (DIDs)](/docs/concepts/glossary#decentralized-identifer), and using [verifiable credentials](/docs/concepts/glossary#verifiable-credentials).
+The tutorials will guide you through setting up a connection, working with [Decentralized Identifiers (DIDs)](/home/concepts/glossary#decentralized-identifer), and using [verifiable credentials](/home/concepts/glossary#verifiable-credentials).
 
-Whether you are new to [self-sovereign identity (SSI)](/docs/concepts/glossary#self-sovereign-identity) or have prior experience, these tutorials will provide the necessary information and skills to build and use SSI-based applications.
+Whether you are new to [self-sovereign identity (SSI)](/home/concepts/glossary#self-sovereign-identity) or have prior experience, these tutorials will provide the necessary information and skills to build and use SSI-based applications.
 
 Throughout all code examples in tutorials, the following conventions are in use:
 * Issuer Keycloak is hosted at `http://localhost:9980/`

--- a/docs/docusaurus/multitenancy/admin-authz-ext-iam.md
+++ b/docs/docusaurus/multitenancy/admin-authz-ext-iam.md
@@ -42,11 +42,13 @@ Despite UMA permissions configured for the user, the agent strictly maintains a 
 ## Endpoints
 
 ### Agent endpoints
+
 | Endpoint       | Description                         | Role          |
 |----------------|-------------------------------------|---------------|
 | `GET /wallets` | List the wallets on the Cloud Agent | Administrator |
 
 ### Keycloak endpoints
+
 | Endpoint                                             | Description           | Role          |
 |------------------------------------------------------|-----------------------|---------------|
 | `POST /realms/{realm}/protocol/openid-connect/token` | Issue a new JWT token | Administrator |

--- a/docs/docusaurus/multitenancy/admin-authz-ext-iam.md
+++ b/docs/docusaurus/multitenancy/admin-authz-ext-iam.md
@@ -8,7 +8,7 @@ allowing users to be authorized under different roles and granting access to par
 
 For the Agent admin authorization, we need to distinguish the administrator of each component:
 
-1. [Agent Administrator](/docs/concepts/glossary#administrator)
+1. [Agent Administrator](/home/concepts/glossary#administrator)
 2. Keycloak Administrator
 
 The same person may also represent these roles.

--- a/docs/docusaurus/multitenancy/tenant-migration.md
+++ b/docs/docusaurus/multitenancy/tenant-migration.md
@@ -1,14 +1,14 @@
 # Migration from `apikey` to `JWT` authentication
 
 The Cloud Agent authentication supports multiple authentication methods simultaneously, which means the user can seamlessly use any available credentials including `apikey` or `JWT` to access the wallet.
-The agent's [UMA](/docs/concepts/glossary#uma) permission resource also exposes the self-service permission endpoint, allowing users to manage the permissions for their wallets.
+The agent's [UMA](/home/concepts/glossary#uma) permission resource also exposes the self-service permission endpoint, allowing users to manage the permissions for their wallets.
 It allows users to transition from `apikey` to `JWT` authentication without admin intervention.
 
 ## Roles
 
 In the migration process from `apikey` to `JWT`, there is only one role:
 
-1. [Tenant](/docs/concepts/glossary#tenant)
+1. [Tenant](/home/concepts/glossary#tenant)
 
 ## Prerequisites
 

--- a/docs/docusaurus/multitenancy/tenant-migration.md
+++ b/docs/docusaurus/multitenancy/tenant-migration.md
@@ -28,6 +28,7 @@ To migrate to `JWT` authentication, users can create a new UMA permission for th
 ## Endpoints
 
 ### Agent endpoints
+
 | Endpoint                                   | Description                            | Role   |
 |--------------------------------------------|----------------------------------------|--------|
 | `GET /wallets`                             | List the wallets on the Cloud Agent    | Tenant |
@@ -36,6 +37,7 @@ To migrate to `JWT` authentication, users can create a new UMA permission for th
 | `GET /did-registrar/dids`                  | List the DIDs inside the wallet        | Tenant |
 
 ### Keycloak endpoints
+
 | Endpoint                                             | Description           | Role   |
 |------------------------------------------------------|-----------------------|--------|
 | `POST /realms/{realm}/protocol/openid-connect/token` | Issue a new JWT token | Tenant |

--- a/docs/docusaurus/multitenancy/tenant-onboarding-ext-iam.md
+++ b/docs/docusaurus/multitenancy/tenant-onboarding-ext-iam.md
@@ -53,6 +53,7 @@ The tenant can access the multi-tenant agent by providing the RPT in the `Author
 ## Endpoints
 
 ### Agent endpoints
+
 | Endpoint                                   | Description                            | Role          |
 |--------------------------------------------|----------------------------------------|---------------|
 | `GET /wallets`                             | List the wallets on the Cloud Agent    | Administrator |
@@ -61,6 +62,7 @@ The tenant can access the multi-tenant agent by providing the RPT in the `Author
 | `GET /did-registrar/dids`                  | List the DIDs inside the wallet        | Tenant        |
 
 ### Keycloak endpoints
+
 | Endpoint                                             | Description                   | Role                  |
 |------------------------------------------------------|-------------------------------|-----------------------|
 | `POST /admin/realms/{realm}/users`                   | Create a new user on Keycloak | Administrator         |

--- a/docs/docusaurus/multitenancy/tenant-onboarding-ext-iam.md
+++ b/docs/docusaurus/multitenancy/tenant-onboarding-ext-iam.md
@@ -1,25 +1,25 @@
 # Tenant Onboarding with External IAM
 
-In the [Tenant Onboarding](./tenant-onboarding.md) tutorial, we explored the basic [IAM](/docs/concepts/glossary#iam) functionality out of the box.
+In the [Tenant Onboarding](./tenant-onboarding.md) tutorial, we explored the basic [IAM](/home/concepts/glossary#iam) functionality out of the box.
 Although it is usable and straightforward, more featureful tools are available for handling identity and access management.
-The agent can seamlessly connect with [Keycloak](/docs/concepts/glossary#keycloak-service) as an external IAM system, allowing the application built on top to utilize the capabilities that come with Keycloak.
+The agent can seamlessly connect with [Keycloak](/home/concepts/glossary#keycloak-service) as an external IAM system, allowing the application built on top to utilize the capabilities that come with Keycloak.
 
-The Cloud Agent leverages standard protocols like [OIDC](/docs/concepts/glossary#oidc) and [UMA](/docs/concepts/glossary#uma) for authentication and access management.
-The user's identity gets established through the ID token, and wallet permissions are searchable using the [RPT (requesting party token)](/docs/concepts/glossary#rpt).
+The Cloud Agent leverages standard protocols like [OIDC](/home/concepts/glossary#oidc) and [UMA](/home/concepts/glossary#uma) for authentication and access management.
+The user's identity gets established through the ID token, and wallet permissions are searchable using the [RPT (requesting party token)](/home/concepts/glossary#rpt).
 
 ## Roles
 
 In tenant management with external IAM, there are 2 roles:
 
-1. [Administrator](/docs/concepts/glossary#administrator)
-2. [Tenant](/docs/concepts/glossary#tenant)
+1. [Administrator](/home/concepts/glossary#administrator)
+2. [Tenant](/home/concepts/glossary#tenant)
 
 ## Prerequisites
 
 1. Keycloak up and running
 2. Keycloak is configured as follows
    1. A realm called `my-realm` is created
-   2. A client called `cloud-agent` under `my-realm` with __authorization__ feature is created. (See [create client instruction](https://www.keycloak.org/docs/latest/authorization_services/index.html#_resource_server_create_client))
+   2. A client called `cloud-agent` under `my-realm` with __authorization__ feature is created. (See [create client instruction](https://www.keycloak.org/home/latest/authorization_services/index.html#_resource_server_create_client))
    3. Make sure the `cloud-agent` client has __direct access grants__ enabled to simplify the login process for this tutorial
 3. the Cloud Agent is up and running
 4. the Cloud Agent is configured with the following environment variables:
@@ -41,7 +41,7 @@ When setting up UMA permissions on the agent, the wallet resource, along with th
 are created on Keycloak according to a predefined convention.
 For flexibility in defining custom policy and permission models,
 administrators can manually create these UMA resources (resource, policy, permission) directly on Keycloak
-using a set of UMA endpoints called [Protection API](/docs/concepts/glossary#protection-api)  (see [Keycloak Protection API](https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_protection_api)).
+using a set of UMA endpoints called [Protection API](/home/concepts/glossary#protection-api)  (see [Keycloak Protection API](https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_protection_api)).
 However, using Protection API to manage permissions is out of the scope of this tutorial.
 
 Once the registration is successful, the tenant can obtain an ID token from Keycloak using any available OIDC flow,
@@ -248,7 +248,7 @@ Example token response (some fields omitted for readability)
 }
 ```
 
-### 2. Request [RPT (requesting party token)](/docs/concepts/glossary#rpt) from access token
+### 2. Request [RPT (requesting party token)](/home/concepts/glossary#rpt) from access token
 
 After the access token is acquired, the next step is to get the RPT token, which holds information about the permissions.
 It is possible to request the RPT by running this command:

--- a/docs/docusaurus/multitenancy/tenant-onboarding-self-service.md
+++ b/docs/docusaurus/multitenancy/tenant-onboarding-self-service.md
@@ -45,6 +45,7 @@ When the agent uses this token for the wallet creation, the agent recognizes it 
 ## Endpoints
 
 ### Agent endpoints
+
 | Endpoint                  | Description                            | Role   |
 |---------------------------|----------------------------------------|--------|
 | `GET /wallets`            | List the wallets on the Cloud Agent    | Tenant |
@@ -52,6 +53,7 @@ When the agent uses this token for the wallet creation, the agent recognizes it 
 | `GET /did-registrar/dids` | List the DIDs inside the wallet        | Tenant |
 
 ### Keycloak endpoints
+
 | Endpoint                                             | Description           | Role   |
 |------------------------------------------------------|-----------------------|--------|
 | `POST /realms/{realm}/protocol/openid-connect/token` | Issue a new JWT token | Tenant |

--- a/docs/docusaurus/multitenancy/tenant-onboarding-self-service.md
+++ b/docs/docusaurus/multitenancy/tenant-onboarding-self-service.md
@@ -1,21 +1,21 @@
 # Tenant Onboarding Self-Service
 
 In the [Tenant Onboarding with External IAM](./tenant-onboarding-ext-iam.md) tutorial,
-we learned how [Keycloak](/docs/concepts/glossary#keycloak-service) helps with user access and how it works together with the agent.
+we learned how [Keycloak](/home/concepts/glossary#keycloak-service) helps with user access and how it works together with the agent.
 To set things up, the admin has to provision the required resources.
 However, relying on the admin for onboarding operations can be restrictive for some use cases.
 For example, some tenants might want to onboard on a self-service agent instance without admin intervention.
 
 By leveraging Keycloak for a self-service agent instance,
-users can self-register or link to other [Identity Providers (IDPs)](/docs/concepts/glossary#idp) to register an account.
+users can self-register or link to other [Identity Providers (IDPs)](/home/concepts/glossary#idp) to register an account.
 Once the account is registered, users can use it to set up their wallets.
-This tutorial will investigate the steps to facilitate this scenario where [administrator](/docs/concepts/glossary#administrator) intervention is unnecessary.
+This tutorial will investigate the steps to facilitate this scenario where [administrator](/home/concepts/glossary#administrator) intervention is unnecessary.
 
 ## Roles
 
 In self-service tenant management with external IAM, there is only one role:
 
-1. [Tenant](/docs/concepts/glossary#tenant)
+1. [Tenant](/home/concepts/glossary#tenant)
 
 ## Prerequisites
 

--- a/docs/docusaurus/multitenancy/tenant-onboarding.md
+++ b/docs/docusaurus/multitenancy/tenant-onboarding.md
@@ -9,8 +9,8 @@ while tenants are users who engage in standard SSI interactions with the Cloud A
 
 In tenant management, there are 2 roles:
 
-1. [Administrator](/docs/concepts/glossary#administrator)
-2. [Tenant](/docs/concepts/glossary#tenant)
+1. [Administrator](/home/concepts/glossary#administrator)
+2. [Tenant](/home/concepts/glossary#tenant)
 
 ## Prerequisites
 

--- a/docs/docusaurus/schemas/create.md
+++ b/docs/docusaurus/schemas/create.md
@@ -1,6 +1,6 @@
 # Create the credential schema
 
-The Identus Platform exposes REST API for creation, fetching, and searching the [credential schema](/docs/concepts/glossary#credential-schema) records.
+The Identus Platform exposes REST API for creation, fetching, and searching the [credential schema](/home/concepts/glossary#credential-schema) records.
 
 The OpenAPI specification and ReDoc documentation describe the endpoint.
 
@@ -12,7 +12,7 @@ The following guide demonstrates how to create a driving license credential sche
 
 ### 1. Define the JSON Schema for the Verifiable Credential
 
-Assume that you need a credential schema for the driving license, and the [verifiable credential](/docs/concepts/glossary#verifiable-credential) must have the following
+Assume that you need a credential schema for the driving license, and the [verifiable credential](/home/concepts/glossary#verifiable-credential) must have the following
 fields:
 
 - emailAddress - the email address of the driver
@@ -81,7 +81,7 @@ Specification.
 
 2. In the client, create a new POST request to either `/cloud-agent/schema-registry/schemas` or `/cloud-agent/schema-registry/schemas/did-url` endpoints. They both take the same payload.
     1. `/cloud-agent/schema-registry/schemas` creates a schema that can later be resolved via HTTP URL
-    2. `/cloud-agent/schema-registry/schemas/did-url` creates a schema that can later be resolved via [DID URL](/docs/concepts/glossary#did-url), the DID includes a service endpoint with the location of the schema registry.
+    2. `/cloud-agent/schema-registry/schemas/did-url` creates a schema that can later be resolved via [DID URL](/home/concepts/glossary#did-url), the DID includes a service endpoint with the location of the schema registry.
 
 Note that the value of the `author` field must match the short form of a PRISM DID that has been created using the same agent. An unpublished DID is sufficient. Please refer to the [Create DID](../dids/create.md) documentation page for more details on how to create a PRISM DID.  
 
@@ -254,7 +254,7 @@ curl -X 'POST' \
 }
 ```
 
-or in case of DID url, the response will be created schema wrapped in [Prism Envelope](/docs/concepts/glossary#prism-envelope)
+or in case of DID url, the response will be created schema wrapped in [Prism Envelope](/home/concepts/glossary#prism-envelope)
 
 ```json
 {
@@ -344,7 +344,7 @@ The response for HTTP URL request should contain the JSON object representing th
 }
 ```
 
-and for DID URL request, response will include the same schema wrapped in [Prism envelope](/docs/concepts/glossary#prism-envelope) response
+and for DID URL request, response will include the same schema wrapped in [Prism envelope](/home/concepts/glossary#prism-envelope) response
 
 ```json
 {
@@ -357,7 +357,7 @@ Schemas created for HTTP URL (`/cloud-agent/schema-registry/schemas`) will not b
 
 
 The Cloud Agent instance's triple `author`, `id`, and `version` are unique.
-So, having a single [DID](/docs/concepts/glossary#decentralized-identifier) reference that the author uses, creating the credential schema with the same `id` and `version`
+So, having a single [DID](/home/concepts/glossary#decentralized-identifier) reference that the author uses, creating the credential schema with the same `id` and `version`
 is impossible.
 
 ### 4. Update the credential schema

--- a/docs/docusaurus/schemas/credential-schema.md
+++ b/docs/docusaurus/schemas/credential-schema.md
@@ -7,8 +7,8 @@ the Identus Platform.
 
 ## 1. Introduction
 
-[Credential Schema](/docs/concepts/glossary#credential-schema) is a data template for [Verifiable Credentials](/docs/concepts/glossary#verifiable-credential).
-It contains [claims](/docs/concepts/glossary#claims) (attributes) of the Verifiable Credentials, credential schema author, type, name, version, and proof
+[Credential Schema](/home/concepts/glossary#credential-schema) is a data template for [Verifiable Credentials](/home/concepts/glossary#verifiable-credential).
+It contains [claims](/home/concepts/glossary#claims) (attributes) of the Verifiable Credentials, credential schema author, type, name, version, and proof
 of authorship.
 By putting schema definitions on a public blockchain, they are available for all verifiers to examine to determine the
 semantic interoperability of the Credential.
@@ -39,7 +39,7 @@ Limitations and constraints of the Identus Platform:
 
 ### Credential Schema
 
-The Credential Schema is a template that defines a set of attributes the [Issuer](/docs/concepts/glossary#issuer) uses to issue the Verifiable Credential.
+The Credential Schema is a template that defines a set of attributes the [Issuer](/home/concepts/glossary#issuer) uses to issue the Verifiable Credential.
 
 ### Schema Registry
 
@@ -47,7 +47,7 @@ The registry is where the Credential Schema is published and available for parti
 
 ### Issuer, Holder, Verifier
 
-These are well-known roles in the [SSI](/docs/concepts/glossary#self-sovereign-identity) domain.
+These are well-known roles in the [SSI](/home/concepts/glossary#self-sovereign-identity) domain.
 
 ## 2. Credential Schema Attributes
 

--- a/docs/docusaurus/schemas/delete.md
+++ b/docs/docusaurus/schemas/delete.md
@@ -1,6 +1,6 @@
 # Delete the credential schema
 
-Unfortunately, after publishing (especially in the [Verifiable Data Registry (VDR)](/docs/concepts/glossary#verifiable-data-registry), deleting the credential schema is impossible.
+Unfortunately, after publishing (especially in the [Verifiable Data Registry (VDR)](/home/concepts/glossary#verifiable-data-registry), deleting the credential schema is impossible.
 
 The Identus Platform doesn't publish the credential schema in the VDR. This capability will get implemented in the later version of the platform. That's why the platform does not expose the REST API for deletion.
 

--- a/docs/docusaurus/schemas/update.md
+++ b/docs/docusaurus/schemas/update.md
@@ -16,7 +16,7 @@ The following guide demonstrates how to update a driving license credential sche
 ### 1. Define the updated JSON Schema for the Verifiable Credential
 
 Assume that you need to update the credential schema from the previous tutorial.
-So, there is an existing driving license, and the [verifiable credential](/docs/concepts/glossary#verifiable-credential) must additionally include two fields:
+So, there is an existing driving license, and the [verifiable credential](/home/concepts/glossary#verifiable-credential) must additionally include two fields:
 
 - bloodType - the blood type of the driver
 - organDonor - indicates whether or not the person is an organ donor
@@ -325,7 +325,7 @@ curl -X 'PUT' \
 }
 ```
 
-If you are updating schema that is DID URL resolvable, the response will be in a forom of [Prism Envelope](/docs/concepts/glossary#prism-envelope), like this:
+If you are updating schema that is DID URL resolvable, the response will be in a forom of [Prism Envelope](/home/concepts/glossary#prism-envelope), like this:
 
 ```json
 {


### PR DESCRIPTION
### Description
- all links in documentation are refactored to point to from `docs` directory to `home` directory

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
