### PR TITLE
fix: add SDJWT value to the OAS enum validation in IssueCredentialRec…

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/http/CreateIssueCredentialRecordRequest.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/http/CreateIssueCredentialRecordRequest.scala
@@ -333,6 +333,7 @@ object CreateIssueCredentialRecordRequest {
           validator = Validator.enumeration(
             List(
               Some("JWT"),
+              Some("SDJWT"),
               Some("AnonCreds")
             )
           )

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/http/IssueCredentialRecord.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/http/IssueCredentialRecord.scala
@@ -186,6 +186,7 @@ object IssueCredentialRecord {
           validator = Validator.enumeration(
             List(
               "JWT",
+              "SDJWT",
               "AnonCreds"
             )
           )


### PR DESCRIPTION
…ord and CreateIssueCredentialRecordRequest

### Description
- added SDJWT value to the enum of IssueCredentialRecord and CreateIssueCredentialRecordRequest

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
