### PR TITLE
build: allow to compare the OAS diff in the PR from the forked branches

### DIFF
--- a/.github/workflows/oasdiff.yml
+++ b/.github/workflows/oasdiff.yml
@@ -54,16 +54,17 @@ jobs:
           REV_TAG: ${{ github.event.inputs.revision_tag }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          PR_REPO_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
         run: |
           echo Revision tag: "$REV_TAG"
           if [[ "$REV_TAG" =~ cloud-agent-v* ]]; then
-            echo "REV_URL=https://raw.githubusercontent.com/hyperledger-identus/cloud-agent/${REV_TAG}/cloud-agent/service/api/http/cloud-agent-openapi-spec.yaml" >> "$GITHUB_ENV"
+            echo "REV_URL=https://raw.githubusercontent.com/${PR_REPO_OWNER}/cloud-agent/${REV_TAG}/cloud-agent/service/api/http/cloud-agent-openapi-spec.yaml" >> "$GITHUB_ENV"
           elif [[ "$REV_TAG" =~ prism-agent-v* ]]; then
-            echo "REV_URL=https://raw.githubusercontent.com/hyperledger-identus/cloud-agent/${REV_TAG}/prism-agent/service/api/http/prism-agent-openapi-spec.yaml" >> "$GITHUB_ENV"
+            echo "REV_URL=https://raw.githubusercontent.com/${PR_REPO_OWNER}/cloud-agent/${REV_TAG}/prism-agent/service/api/http/prism-agent-openapi-spec.yaml" >> "$GITHUB_ENV"
           elif [[ "$REV_TAG" == 'main' ]]; then
-            echo "REV_URL=https://raw.githubusercontent.com/hyperledger-identus/cloud-agent/${REV_TAG}/cloud-agent/service/api/http/cloud-agent-openapi-spec.yaml" >> "$GITHUB_ENV"
+            echo "REV_URL=https://raw.githubusercontent.com/${PR_REPO_OWNER}/cloud-agent/${REV_TAG}/cloud-agent/service/api/http/cloud-agent-openapi-spec.yaml" >> "$GITHUB_ENV"
           elif [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
-            echo "REV_URL=https://raw.githubusercontent.com/hyperledger-identus/cloud-agent/${BRANCH_NAME}/cloud-agent/service/api/http/cloud-agent-openapi-spec.yaml" >> "$GITHUB_ENV"
+            echo "REV_URL=https://raw.githubusercontent.com/${PR_REPO_OWNER}/cloud-agent/${BRANCH_NAME}/cloud-agent/service/api/http/cloud-agent-openapi-spec.yaml" >> "$GITHUB_ENV"
           fi
 
       - name: Check URLS


### PR DESCRIPTION
### Description
When the PR is made from the forked branch, oasdiff workflow doesn't resolve the cloud-agent OAS revision link.
The current PR resolves the issue.

### Checklist
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
