### PR TITLE
fix: return proper error response for unauthorized access

### DIFF
--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/connect/controller/ConnectionEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/connect/controller/ConnectionEndpoints.scala
@@ -68,6 +68,7 @@ object ConnectionEndpoints {
         oneOf(
           FailureVariant.forbidden,
           FailureVariant.badRequest,
+          FailureVariant.unauthorized,
           FailureVariant.internalServerError
         )
       )
@@ -100,6 +101,7 @@ object ConnectionEndpoints {
           FailureVariant.notFound,
           FailureVariant.badRequest,
           FailureVariant.forbidden,
+          FailureVariant.unauthorized,
           FailureVariant.internalServerError
         )
       )
@@ -138,7 +140,8 @@ object ConnectionEndpoints {
         oneOf(
           FailureVariant.forbidden,
           FailureVariant.badRequest,
-          FailureVariant.internalServerError
+          FailureVariant.unauthorized,
+          FailureVariant.internalServerError,
         )
       )
       .name("getConnections")
@@ -180,6 +183,7 @@ object ConnectionEndpoints {
         oneOf(
           FailureVariant.forbidden,
           FailureVariant.badRequest,
+          FailureVariant.unauthorized,
           FailureVariant.internalServerError
         )
       )


### PR DESCRIPTION
### Description
when making a connection request without an APIKey: . it results in a 500 error repsonse (which is default : [unexpected error](https://tapir.softwaremill.com/en/latest/tutorials/04_errors.html#unexpected-errors)) . But it logs the exception rather than return the response returned as jsonBody[ErrorResponse]. This PR fixes it with `unauthorized` FailureVariant 

ErrorResponse(401,error:AuthenticationError:InvalidCredentials ** ,Invalid Credentials,Some(ApiKey key is not provided),error:instance:01932437-c12a-4915-9c54-45afd530222e)

### Alternatives Considered (optional)
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
