### PR TITLE
fix: Commit message guideline broken link fixed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,6 @@ If you find a bug in the source code, you can help us by [submitting an issue](#
 
 Even better, you can [submit a Pull Request](#submit-pr) with a fix.
 
-
 ## <a name="feature"></a> Missing a Feature?
 
 You can *request* a new feature by [submitting an issue](#submit-issue) to our GitHub Repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ After your pull request is merged, you can safely delete your branch and pull th
 
 ## <a name="commit"></a> Commit Message Format
 
-Please, follow our [Commit Message guidelines](https://handbook.atalaprism.io/engineering/sdlc/commit-guidelines) for all commits you made, and make sure your PR title is following this format.
+Please, follow our [Commit Message guidelines](https://github.com/hyperledger-identus/identus/blob/main/CONTRIBUTING.md#commits) for all commits you made, and make sure your PR title is following this format.
 
 ## <a name="rules"></a> Coding Rules
 


### PR DESCRIPTION
### Description
Old link below points to a 404

https://handbook.atalaprism.io/engineering/sdlc/commit-guidelines

replaced it with 

https://github.com/hyperledger-identus/identus/blob/main/CONTRIBUTING.md#commits

### Alternatives Considered (optional)
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
