### PR TITLE
fix: mitigation to #1495 (update the outdated url)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,7 +128,7 @@ lazy val D = new {
   val jwtZio = "com.github.jwt-scala" %% "jwt-zio-json" % V.jwtZioVersion
   val jsonCanonicalization: ModuleID = "io.github.erdtman" % "java-json-canonicalization" % "1.1"
   val titaniumJsonLd: ModuleID = "com.apicatalog" % "titanium-json-ld" % "1.4.0"
-  val jakartaJson: ModuleID = "org.glassfish" % "jakarta.json" % "2.0.1"
+  val jakartaJson: ModuleID = "org.glassfish" % "jakarta.json" % "2.0.1" // used by titanium-json-ld
   val ironVC: ModuleID = "com.apicatalog" % "iron-verifiable-credentials" % "0.14.0"
   val scodecBits: ModuleID = "org.scodec" %% "scodec-bits" % "1.1.38"
   val jaywayJsonPath: ModuleID = "com.jayway.jsonpath" % "json-path" % "2.9.0"
@@ -906,7 +906,7 @@ lazy val cloudAgentServer = project
       ExclusionRule("com.google.protobuf", "protobuf-javalite")
     ),
     Compile / mainClass := Some("org.hyperledger.identus.agent.server.MainApp"),
-    Docker / maintainer := "atala-coredid@iohk.io", //TODO: clarify the contact emale of the project
+    Docker / maintainer := "atala-coredid@iohk.io", // TODO: clarify the contact emale of the project
     Docker / dockerUsername := Some("hyperledgeridentus"), // https://hub.docker.com/u/hyperledgeridentus
     Docker / dockerRepository := Some("docker.io"),
     dockerExposedPorts := Seq(8085, 8090),

--- a/cloud-agent/service/api/http/cloud-agent-openapi-spec.yaml
+++ b/cloud-agent/service/api/http/cloud-agent-openapi-spec.yaml
@@ -7956,7 +7956,7 @@ components:
           description: List of JSON-LD contexts
           example:
           - https://www.w3.org/2018/credentials/v1
-          - https://w3id.org/vc/status-list/2021/v1
+          - https://w3c.github.io/vc-bitstring-status-list/contexts/2021/v1.jsonld
           type: array
           uniqueItems: true
           items:

--- a/docs/docusaurus/credentials/revocation.md
+++ b/docs/docusaurus/credentials/revocation.md
@@ -30,7 +30,7 @@ Every credential will contain the property `credentialStatus`, which will look l
   "proof" : {...},
   "@context" : [
     "https://www.w3.org/2018/credentials/v1",
-    "https://w3id.org/vc/status-list/2021/v1"
+    "https://w3c.github.io/vc-bitstring-status-list/contexts/2021/v1.jsonld"
   ],
   "type" : [
     "VerifiableCredential",
@@ -94,7 +94,7 @@ We currently support 2 types of proofs:
   },
   "@context" : [
     "https://www.w3.org/2018/credentials/v1",
-    "https://w3id.org/vc/status-list/2021/v1"
+    "https://w3c.github.io/vc-bitstring-status-list/contexts/2021/v1.jsonld"
   ],
   "type" : [
     "VerifiableCredential",
@@ -124,7 +124,7 @@ We currently support 2 types of proofs:
   },
   "@context" : [
     "https://www.w3.org/2018/credentials/v1",
-    "https://w3id.org/vc/status-list/2021/v1"
+    "https://w3c.github.io/vc-bitstring-status-list/contexts/2021/v1.jsonld"
   ],
   "type" : [
     "VerifiableCredential",

--- a/pollux/vc-jwt/src/main/scala/org/hyperledger/identus/pollux/vc/jwt/revocation/VCStatusList2021.scala
+++ b/pollux/vc-jwt/src/main/scala/org/hyperledger/identus/pollux/vc/jwt/revocation/VCStatusList2021.scala
@@ -57,7 +57,7 @@ object VCStatusList2021 {
       val w3Credential = W3cCredentialPayload(
         `@context` = Set(
           "https://www.w3.org/2018/credentials/v1",
-          "https://w3id.org/vc/status-list/2021/v1"
+          "https://w3c.github.io/vc-bitstring-status-list/contexts/2021/v1.jsonld"
         ),
         maybeId = Some(vcId),
         `type` = Set("VerifiableCredential", "StatusList2021Credential"),

--- a/pollux/vc-jwt/src/test/scala/org/hyperledger/identus/pollux/vc/jwt/JWTVerificationTest.scala
+++ b/pollux/vc-jwt/src/test/scala/org/hyperledger/identus/pollux/vc/jwt/JWTVerificationTest.scala
@@ -44,7 +44,7 @@ object JWTVerificationTest extends ZIOSpecDefault {
                                               |  },
                                               |  "@context" : [
                                               |    "https://www.w3.org/2018/credentials/v1",
-                                              |    "https://w3id.org/vc/status-list/2021/v1"
+                                              |    "https://w3c.github.io/vc-bitstring-status-list/contexts/2021/v1.jsonld"
                                               |  ],
                                               |  "type" : [
                                               |    "VerifiableCredential",


### PR DESCRIPTION
### Description
Mitigation the problem by update the outdated url

### Alternatives Considered (optional)
The problem is probably our https client on code that does not follow the redirect.
Having several HTTP clients made with different libraries does not help...

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
