### PR TITLE
build: deactivate the megalinter workflow on pull_request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@
 name: MegaLinter
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 env: # Comment env block if you don't want to apply fixes
   # Apply linter fixes configuration


### PR DESCRIPTION
### Description
- deactivate the megalinter run on the pull request (it can be run on workflow_dispatch)

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
