### PR TITLE
fix: add LRUDocumentLoader to optimize the JsonLD.toRdf call, fix #1553

### DIFF
--- a/shared/json/src/main/scala/org/hyperledger/identus/shared/json/Json.scala
+++ b/shared/json/src/main/scala/org/hyperledger/identus/shared/json/Json.scala
@@ -2,6 +2,7 @@ package org.hyperledger.identus.shared.json
 
 import com.apicatalog.jsonld.document.JsonDocument
 import com.apicatalog.jsonld.http.media.MediaType
+import com.apicatalog.jsonld.loader.{DocumentLoader, HttpLoader, LRUDocumentCache}
 import com.apicatalog.jsonld.JsonLd
 import com.apicatalog.rdf.Rdf
 import io.setl.rdf.normalization.RdfNormalize
@@ -36,7 +37,7 @@ object Json {
     Try {
       val inputStream = new ByteArrayInputStream(jsonLdStr.getBytes)
       val document = JsonDocument.of(inputStream)
-      val rdfDataset = JsonLd.toRdf(document).get
+      val rdfDataset = JsonLd.toRdf(document).loader(lruDocumentLoader).get
       val normalized = RdfNormalize.normalize(rdfDataset)
       val writer = new StringWriter
       val rdfWriter = Rdf.createWriter(MediaType.N_QUADS, writer)
@@ -45,4 +46,6 @@ object Json {
       bytes
     }.toEither
   }
+
+  lazy val lruDocumentLoader: DocumentLoader = new LRUDocumentCache(HttpLoader.defaultInstance(), 1024)
 }

--- a/shared/json/src/test/scala/org/hyperledger/identus/shared/json/JsonLdLoadSpec.scala
+++ b/shared/json/src/test/scala/org/hyperledger/identus/shared/json/JsonLdLoadSpec.scala
@@ -1,0 +1,54 @@
+package org.hyperledger.identus.shared.json
+
+import zio.test.*
+import zio.test.Assertion.*
+import zio.ZIO
+import com.apicatalog.jsonld.JsonLd
+import com.apicatalog.jsonld.document.JsonDocument
+import org.hyperledger.identus.shared.json.Json.*
+
+import java.io.ByteArrayInputStream
+
+object JsonLdLoadSpec extends ZIOSpecDefault {
+  
+  private val jsonLdString = """{
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      {
+        "id": "@id",
+        "type": "@type",
+        "name": "http://schema.org/name"
+      }
+    ],
+    "id": "https://example.com/credentials/123",
+    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+    "issuer": {
+      "id": "https://example.edu/issuers/565049",
+      "name": "Example University"
+    },
+    "credentialSubject": {
+      "id": "https://example.edu/students/alice",
+      "degree": {
+        "type": ["BachelorDegree", "UniversityDegree"],
+        "name": "Bachelor of Science and Arts"
+      }
+    }
+  }"""
+  
+  val jsonLDDocument = JsonDocument.of(new ByteArrayInputStream(jsonLdString.getBytes))
+
+  def loadJsonLd: ZIO[Any, Throwable, Unit] = {
+    ZIO.attempt {
+      JsonLd.toRdf(jsonLDDocument)
+        .loader(Json.lruDocumentLoader) // It fails with an error without the lru loader
+        .get
+    }.unit
+  }
+
+  override def spec = suite("JsonLdLoadSpec")(
+    test("Execute JsonLd.toRdf 1000 times") {
+      val loadJsonLdRepeatedly = ZIO.foreach(1 to 1000)(_ => loadJsonLd)
+      assertZIO(loadJsonLdRepeatedly.exit)(succeeds(anything))
+    }
+  )
+}

--- a/shared/json/src/test/scala/org/hyperledger/identus/shared/json/JsonLdLoadSpec.scala
+++ b/shared/json/src/test/scala/org/hyperledger/identus/shared/json/JsonLdLoadSpec.scala
@@ -1,16 +1,16 @@
 package org.hyperledger.identus.shared.json
 
+import com.apicatalog.jsonld.document.JsonDocument
+import com.apicatalog.jsonld.JsonLd
+import org.hyperledger.identus.shared.json.Json.*
 import zio.test.*
 import zio.test.Assertion.*
 import zio.ZIO
-import com.apicatalog.jsonld.JsonLd
-import com.apicatalog.jsonld.document.JsonDocument
-import org.hyperledger.identus.shared.json.Json.*
 
 import java.io.ByteArrayInputStream
 
 object JsonLdLoadSpec extends ZIOSpecDefault {
-  
+
   private val jsonLdString = """{
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
@@ -34,12 +34,13 @@ object JsonLdLoadSpec extends ZIOSpecDefault {
       }
     }
   }"""
-  
+
   val jsonLDDocument = JsonDocument.of(new ByteArrayInputStream(jsonLdString.getBytes))
 
   def loadJsonLd: ZIO[Any, Throwable, Unit] = {
     ZIO.attempt {
-      JsonLd.toRdf(jsonLDDocument)
+      JsonLd
+        .toRdf(jsonLDDocument)
         .loader(Json.lruDocumentLoader) // It fails with an error without the lru loader
         .get
     }.unit


### PR DESCRIPTION
### Description
The JSON-LD document resolution (toRfd call) is optimized to use the LRUDocumentLoader. This PR fixes #1553 issue.

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
