### PR TITLE
fix: LOG_LEVEL environment variable and cleanup logging entries

### DIFF
--- a/cloud-agent/service/server/src/main/resources/logback.xml
+++ b/cloud-agent/service/server/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
   <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
   <import class="ch.qos.logback.core.ConsoleAppender"/>
 
-  <property name="LOG_LEVEL" value="${LOG_LEVEL:info}"/>
+  <property name="LOG_LEVEL" value="${LOG_LEVEL:-info}"/>
 
   <appender name="STDOUT" class="ConsoleAppender">
     <encoder class="PatternLayoutEncoder">
@@ -18,6 +18,13 @@
   <logger name="org.apache.kafka.clients" level="WARN">
     <appender-ref ref="STDOUT" />
   </logger>
+  <logger name="com.zaxxer.hikari" level="WARN">
+    <appender-ref ref="STDOUT" />
+  </logger>
+  <logger name="io.netty" level="WARN">
+    <appender-ref ref="STDOUT" />
+  </logger>
+
   <root level="${LOG_LEVEL}">
     <appender-ref ref="STDOUT"/>
   </root>

--- a/cloud-agent/service/server/src/main/resources/logback.xml
+++ b/cloud-agent/service/server/src/main/resources/logback.xml
@@ -24,6 +24,12 @@
   <logger name="io.netty" level="WARN">
     <appender-ref ref="STDOUT" />
   </logger>
+  <logger name="org.flywaydb.core.internal" level="WARN">
+    <appender-ref ref="STDOUT" />
+  </logger>
+  <logger name="org.http4s.blaze" level="WARN">
+    <appender-ref ref="STDOUT" />
+  </logger>
 
   <root level="${LOG_LEVEL}">
     <appender-ref ref="STDOUT"/>

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/LogUtils.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/LogUtils.scala
@@ -14,7 +14,7 @@ object LogUtils {
       def extraLog = zio.internal.stacktracer.Tracer.instance.unapply(trace) match
         case Some((location: String, file: String, line: Int)) =>
           val methodName: String = location.split('.').toSeq.takeRight(2).mkString(".")
-          ZIO.log(s"Trace $methodName")
+          ZIO.logDebug(s"Trace $methodName")
         case _ => ZIO.unit // In principle this will not happen
       ctx.request.headers.find(_.name.equalsIgnoreCase(headerName)) match
         case None         => (extraLog &> job)

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/notification/WebhookPublisher.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/notification/WebhookPublisher.scala
@@ -58,9 +58,9 @@ class WebhookPublisher(
 
   private def pollAndNotify[A](consumer: EventConsumer[A])(implicit encoder: JsonEncoder[A]) = {
     for {
-      _ <- ZIO.log(s"Polling $parallelism event(s)")
+      _ <- ZIO.logDebug(s"Polling $parallelism event(s)")
       events <- consumer.poll(parallelism).mapError(e => UnexpectedError(e.toString))
-      _ <- ZIO.log(s"Got ${events.size} event(s)")
+      _ <- ZIO.logDebug(s"Got ${events.size} event(s)")
       webhookConfig <- ZIO
         .foreach(events.map(_.walletId).toSet.toList) { walletId =>
           walletService.listWalletNotifications

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/MainApp.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/MainApp.scala
@@ -89,8 +89,8 @@ object MainApp extends ZIOAppDefault {
 
   // FIXME: remove this when db app user have correct privileges provisioned by k8s operator.
   // This should be executed before migration to have correct privilege for new objects.
-  private val preMigrations = for {
-    _ <- ZIO.logInfo("running pre-migration steps.")
+  lazy private val preMigrations = for {
+    _ <- ZIO.logDebug("Running SQL pre-migration steps.")
     appConfig <- ZIO.service[AppConfig].provide(SystemModule.configLayer)
     _ <- PolluxMigrations
       .initDbPrivileges(appConfig.pollux.database.appUsername)
@@ -103,11 +103,11 @@ object MainApp extends ZIOAppDefault {
       .provide(RepoModule.agentTransactorLayer)
   } yield ()
 
-  private val migrations = for {
+  lazy private val migrations = for {
     _ <- ZIO.serviceWithZIO[PolluxMigrations](_.migrateAndRepair)
     _ <- ZIO.serviceWithZIO[ConnectMigrations](_.migrateAndRepair)
     _ <- ZIO.serviceWithZIO[AgentMigrations](_.migrateAndRepair)
-    _ <- ZIO.logInfo("Running post-migration RLS checks for DB application users")
+    _ <- ZIO.logDebug("Running SQL post-migration RLS checks for DB application users")
     _ <- PolluxMigrations.validateRLS.provide(RepoModule.polluxContextAwareTransactorLayer)
     _ <- ConnectMigrations.validateRLS.provide(RepoModule.connectContextAwareTransactorLayer)
     _ <- AgentMigrations.validateRLS.provide(RepoModule.agentContextAwareTransactorLayer)
@@ -115,41 +115,21 @@ object MainApp extends ZIOAppDefault {
   override def run: ZIO[Any, Throwable, Unit] = {
 
     val app = for {
-      _ <- Console
-        .printLine(s"""
-      |██╗██████╗ ███████╗███╗   ██╗████████╗██╗   ██╗███████╗
-      |██║██╔══██╗██╔════╝████╗  ██║╚══██╔══╝██║   ██║██╔════╝
-      |██║██║  ██║█████╗  ██╔██╗ ██║   ██║   ██║   ██║███████╗
-      |██║██║  ██║██╔══╝  ██║╚██╗██║   ██║   ██║   ██║╚════██║
-      |██║██████╔╝███████╗██║ ╚████║   ██║   ╚██████╔╝███████║
-      |╚═╝╚═════╝ ╚══════╝╚═╝  ╚═══╝   ╚═╝    ╚═════╝ ╚══════╝
-      |
-      | ██████╗██╗      ██████╗ ██╗   ██╗██████╗
-      |██╔════╝██║     ██╔═══██╗██║   ██║██╔══██╗
-      |██║     ██║     ██║   ██║██║   ██║██║  ██║
-      |██║     ██║     ██║   ██║██║   ██║██║  ██║
-      |╚██████╗███████╗╚██████╔╝╚██████╔╝██████╔╝
-      | ╚═════╝╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝
-      |
-      | █████╗  ██████╗ ███████╗███╗   ██╗████████╗
-      |██╔══██╗██╔════╝ ██╔════╝████╗  ██║╚══██╔══╝
-      |███████║██║  ███╗█████╗  ██╔██╗ ██║   ██║
-      |██╔══██║██║   ██║██╔══╝  ██║╚██╗██║   ██║
-      |██║  ██║╚██████╔╝███████╗██║ ╚████║   ██║
-      |╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝   ╚═╝
-      |
-      |version: ${buildinfo.BuildInfo.version}
-      |
-      |""".stripMargin)
-        .ignore
-
       appConfig <- ZIO.service[AppConfig].provide(SystemModule.configLayer)
       flags = appConfig.featureFlag
-      _ <- Console.printLine(s"""### Feature Flags: ####
-         | - Support for the credential type JWT VC is ${if (flags.enableJWT) "ENABLED" else "DISABLED"}
-         | - Support for the credential type SD JWT VC is ${if (flags.enableSDJWT) "ENABLED" else "DISABLED"}
-         | - Support for the credential type  Anoncred is ${if (flags.enableAnoncred) "ENABLED" else "DISABLED"}
-         |""")
+      _ <- Console.printLine(s"""
+           |██████████████████████████████████████████████████████████████████
+           |Starting Identus Cloud-Agent version: ${buildinfo.BuildInfo.version}
+           |
+           |HTTP server endpoint is setup as '${appConfig.agent.httpEndpoint.publicEndpointUrl}'
+           |DIDComm server endpoint is setup as '${appConfig.agent.didCommEndpoint.publicEndpointUrl}'
+           |
+           |Feature Flags:
+           | - Support for the credential type JWT VC is ${if (flags.enableJWT) "ENABLED" else "DISABLED"}
+           | - Support for the credential type SD JWT VC is ${if (flags.enableSDJWT) "ENABLED" else "DISABLED"}
+           | - Support for the credential type AnonCreds is ${if (flags.enableAnoncred) "ENABLED" else "DISABLED"}
+           |██████████████████████████████████████████████████████████████████
+           |""".stripMargin)
       _ <- preMigrations
       _ <- migrations
       app <- CloudAgentApp.run

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/Modules.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/Modules.scala
@@ -55,8 +55,6 @@ object SystemModule {
       ret: AppConfig <- TypesafeConfigProvider
         .fromTypesafeConfig(ConfigFactory.load())
         .load(AppConfig.config)
-      _ <- ZIO.log(s"HTTP server endpoint is setup as '${ret.agent.httpEndpoint.publicEndpointUrl}'")
-      _ <- ZIO.log(s"DIDComm server endpoint is setup as '${ret.agent.didCommEndpoint.publicEndpointUrl}'")
     } yield ret
   )
 

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/IssueBackgroundJobs.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/IssueBackgroundJobs.scala
@@ -186,7 +186,7 @@ object IssueBackgroundJobs extends BackgroundJobsHelper {
               _,
               _,
             ) =>
-          ZIO.debug(s" Connectionless InvitationGenerated record received no processing required") *> ZIO.unit
+          ZIO.logDebug(s" Connectionless InvitationGenerated record received no processing required") *> ZIO.unit
         // Offer should be sent from Issuer to Holder
         case IssueCredentialRecord(
               id,

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/StatusListJobs.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/StatusListJobs.scala
@@ -32,7 +32,7 @@ object StatusListJobs extends BackgroundJobsHelper {
       trigger = for {
         credentialStatusListService <- ZIO.service[CredentialStatusListService]
         walletAndStatusListIds <- credentialStatusListService.getCredentialStatusListIds
-        _ <- ZIO.logInfo(s"Triggering status list revocation sync for '${walletAndStatusListIds.size}' status lists")
+        _ <- ZIO.logDebug(s"Triggering status list revocation sync for '${walletAndStatusListIds.size}' status lists")
         _ <- ZIO.foreach(walletAndStatusListIds) { (walletId, statusListId) =>
           producer.produce(TOPIC_NAME, walletId.toUUID, WalletIdAndRecordId(walletId.toUUID, statusListId))
         }
@@ -56,7 +56,7 @@ object StatusListJobs extends BackgroundJobsHelper {
     Unit
   ] = {
     (for {
-      _ <- ZIO.logDebug(s"!!! Handling recordId: ${message.value} via Kafka queue")
+      _ <- ZIO.logDebug(s"Handling recordId: ${message.value} via Kafka queue")
       credentialStatusListService <- ZIO.service[CredentialStatusListService]
       walletAccessContext = WalletAccessContext(WalletId.fromUUID(message.value.walletId))
       statusListWithCreds <- credentialStatusListService

--- a/cloud-agent/service/wallet-api/src/main/scala/org/hyperledger/identus/agent/walletapi/service/ManagedDIDServiceImpl.scala
+++ b/cloud-agent/service/wallet-api/src/main/scala/org/hyperledger/identus/agent/walletapi/service/ManagedDIDServiceImpl.scala
@@ -125,11 +125,7 @@ class ManagedDIDServiceImpl private[walletapi] (
     for {
       _ <- ZIO
         .fromEither(ManagedDIDTemplateValidator.validate(didTemplate))
-        .mapError { x =>
-          println("x: " + x)
-
-          CreateManagedDIDError.InvalidArgument(x)
-        }
+        .mapError(CreateManagedDIDError.InvalidArgument.apply)
       _ <- ZIO.logInfo(s"Old did template after validation: $didTemplate")
       newDidTemplate = didTemplate.copy(services = didTemplate.services)
       _ <- ZIO.logInfo(s"Creating managed DID with template2: $newDidTemplate")

--- a/cloud-agent/service/wallet-api/src/test/scala/org/hyperledger/identus/agent/walletapi/benchmark/KeyDerivation.scala
+++ b/cloud-agent/service/wallet-api/src/test/scala/org/hyperledger/identus/agent/walletapi/benchmark/KeyDerivation.scala
@@ -93,7 +93,7 @@ object KeyDerivation extends ZIOSpecDefault, VaultTestContainerSupport {
 
   private def deriveKeyWarmUp(n: Int = 10000) = {
     for {
-      _ <- ZIO.debug("running key derivation warm-up")
+      _ <- ZIO.logDebug("running key derivation warm-up")
       apollo <- ZIO.service[Apollo]
       _ <- ZIO
         .foreach(1 to n) { i =>
@@ -105,7 +105,7 @@ object KeyDerivation extends ZIOSpecDefault, VaultTestContainerSupport {
   private def vaultWarmUp(n: Int = 100) = {
     for {
       vaultClient <- ZIO.service[VaultKVClient]
-      _ <- ZIO.debug("running vault warm-up")
+      _ <- ZIO.logDebug("running vault warm-up")
       _ <- ZIO.foreach(1 to n) { i =>
         vaultClient.set(s"secret/warm-up/key-$i", Map("hello" -> "world"))
       }
@@ -133,6 +133,6 @@ object KeyDerivation extends ZIOSpecDefault, VaultTestContainerSupport {
     val p90 = sortedDurationInMicro.apply((0.90 * n).toInt)
     val p99 = sortedDurationInMicro.apply((0.99 * n).toInt)
     val max = sortedDurationInMicro.last
-    ZIO.debug(s"execution time in us. avg: $avg | p50: $p50 | p75: $p75 | p90: $p90 | p99: $p99 | max: $max")
+    ZIO.logDebug(s"execution time in us. avg: $avg | p50: $p50 | p75: $p75 | p90: $p90 | p99: $p99 | max: $max")
   }
 }

--- a/mercury/agent-didcommx/src/main/scala/org/hyperledger/identus/mercury/MessagingService.scala
+++ b/mercury/agent-didcommx/src/main/scala/org/hyperledger/identus/mercury/MessagingService.scala
@@ -131,7 +131,7 @@ object MessagingService {
           else didCommService.packEncrypted(msg = finalMessage, to = to)
 
         _ <- ZIO.log(s"Sending a Message to '$serviceEndpoint'")
-        _ <- ZIO.debug(s"Plain message: $msg")
+        _ <- ZIO.logDebug(s"Plain message: $msg")
         resp <- org.hyperledger.identus.mercury.HttpClient
           .postDIDComm(url = serviceEndpoint, data = encryptedMessage.string)
           .catchAll { case ex => ZIO.fail(SendMessageError(ex, Some(encryptedMessage.string))) }

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/uriResolvers/DidUrlResolver.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/uriResolvers/DidUrlResolver.scala
@@ -58,7 +58,7 @@ class DidUrlResolver(httpUrlResolver: HttpUrlResolver, didResolver: DidResolver)
       validatedResult <- result.fromJson[PrismEnvelopeData] match {
         case Right(env) => validateResourceIntegrity(env, maybeResourceHash)
         case Left(err) =>
-          ZIO.debug("Error parsing response as PrismEnvelope. Falling back to plain json") *> ZIO.succeed(result)
+          ZIO.logDebug("Error parsing response as PrismEnvelope. Falling back to plain json") *> ZIO.succeed(result)
       }
 
     } yield validatedResult

--- a/shared/core/src/main/scala/org/hyperledger/identus/shared/http/GenericUriResolver.scala
+++ b/shared/core/src/main/scala/org/hyperledger/identus/shared/http/GenericUriResolver.scala
@@ -20,7 +20,7 @@ class GenericUriResolver(resolvers: Map[String, UriResolver]) extends UriResolve
   override def resolve(uri: String): IO[GenericUriResolverError, String] = {
     val parsedUri = Uri.parseTry(uri)
 
-    ZIO.debug(s"Resolving resource from uri: $uri") *>
+    ZIO.logDebug(s"Resolving resource from uri: $uri") *>
       ZIO.fromTry(parsedUri).mapError(_ => InvalidUri(uri)).flatMap {
         case url: Url =>
           url.schemeOption.fold(ZIO.fail(InvalidUri(uri)))(schema =>
@@ -34,8 +34,8 @@ class GenericUriResolver(resolvers: Map[String, UriResolver]) extends UriResolve
                           .fromTry(Try(Base64Utils.decodeUrlToString(env.resource)))
                           .mapError(_ => DidUriResponseNotEnvelope(uri))
                       case Left(err) =>
-                        ZIO.debug(s"Failed to parse response as PrismEnvelope: $err") *>
-                          ZIO.debug("Falling back to returning the response as is") *>
+                        ZIO.logDebug(s"Failed to parse response as PrismEnvelope: $err") *>
+                          ZIO.logDebug("Falling back to returning the response as is") *>
                           ZIO.succeed(res)
                   case _ => ZIO.succeed(res)
               }


### PR DESCRIPTION
### Description
- fix LOG_LEVEL environment variable in the logback.xml file
- set WARN log level in 3rd party libraries: blaze, flyway, hikari, netty
- rename ZIO.debug (writes to the stdout) to ZIO.logDebug to control the logging level
- fixed duplicates of the message about the configured URL of API and DIDComm
- simplified the salutation message

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
