### PR TITLE
chore!: trigger major version release

### DIFF
--- a/cloud-agent/client/generator/publish-clients.sh
+++ b/cloud-agent/client/generator/publish-clients.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-AGENT_VERSION=${VERSION_TAG:13}
+# Parse the version from the revision, beta or tag (everything that comes after 'v' in the VERSION_TAG)
+AGENT_VERSION=$(echo "$VERSION_TAG" | sed -E 's/.*v([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\.]+)?).*/\1/')
 echo version=${AGENT_VERSION}
 
 # install dependencies

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/castor/controller/DIDRegistrarEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/castor/controller/DIDRegistrarEndpoints.scala
@@ -147,8 +147,8 @@ object DIDRegistrarEndpoints {
       """Update DID in the agent's wallet and post the update operation to the VDR.
         |Only the DID with status `PUBLISHED` can be updated.
         |This endpoint updates the DID document from the last confirmed operation.
-        |The update operation is asynchornous operation and the agent will reject
-        |a new update request if the previous operation is not yet comfirmed.""".stripMargin
+        |The update operation is asynchronous operation and the agent will reject
+        |a new update request if the previous operation is not yet confirmed.""".stripMargin
     )
 
   val deactivateManagedDid: Endpoint[

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -30,7 +30,7 @@ export default {
             prepareCmd: 'sbt "set ThisBuild / version:=\\\"${nextRelease.version}\\\"" "dumpLicenseReportAggregate" && cp ./target/license-reports/root-licenses.md ./DEPENDENCIES.md'
         }],
         ["@semantic-release/exec", {
-            "prepareCmd": "docker buildx build --platform=linux/arm64,linux/amd64 --push -t ${DOCKERHUB_ORG}/identus-cloud-agent:${nextRelease.version} ./cloud-agent/service/server/target/docker/stage"
+            prepareCmd: "docker buildx build --platform=linux/arm64,linux/amd64 --push -t ${process.env.DOCKERHUB_ORG}/identus-cloud-agent:${nextRelease.version} ./cloud-agent/service/server/target/docker/stage"
         }],
         ["@semantic-release/exec", {
             prepareCmd: "sed -i.bak \"s/AGENT_VERSION=.*/AGENT_VERSION=${nextRelease.version}/\" ./infrastructure/local/.env && rm -f ./infrastructure/local/.env.bak"

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,10 +1,8 @@
-/**
- * @type {import('semantic-release').GlobalConfig}
- */
 export default {
     branches: [
         'main',
         '+([0-9])?(.{+([0-9]),x}).x',
+        { name: 'beta', prerelease: true }
     ],
     plugins: [
         ['@semantic-release/commit-analyzer', {
@@ -48,14 +46,6 @@ export default {
                 "infrastructure/local/.env"
             ],
             message: "chore(release): cut the Identus Cloud agent ${nextRelease.version} release\n\n${nextRelease.notes} [skip ci]\n\nSigned-off-by: Hyperledger Bot <hyperledger-bot@hyperledger.org>"
-        }],
-        ["semantic-release-slack-bot", {
-            notifyOnSuccess: true,
-            notifyOnFail: true,
-            markdownReleaseNotes: true,
-            onSuccessTemplate: {
-                text: "A new version of Identus Cloud Agent successfully released!\nVersion: `$npm_package_version`\nTag: $repo_url/releases/tag/cloud-agent-v$npm_package_version\n\nRelease notes:\n$release_notes"
-            }
         }],
     ],
     tagFormat: "v${version}"

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,3 +1,6 @@
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
 export default {
     branches: [
         'main',


### PR DESCRIPTION
### Description
Synthetic commit to trigger the major version release of the cloud-agent in the semantic-release workflow.

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
