### PR TITLE
build: fix typo in repository causing flaky scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.8.3
+version = 3.9.6
 runner.dialect = scala3
 
 maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -434,7 +434,7 @@ val commonSetttings = Seq(
   // Needed for Kotlin coroutines that support new memory management mode
   resolvers += "JetBrains Space Maven Repository" at "https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven",
   // Needed for com.github.multiformats:java-multibase
-  resolvers += "scijava" at "	https://maven.scijava.org/content/repositories/public/",
+  resolvers += "scijava" at "https://maven.scijava.org/content/repositories/public/",
   // Override 'updateLicenses' for all project to inject custom DependencyResolution.
   // https://github.com/sbt/sbt-license-report/blob/9675cedb19c794de1119cbcf46a255fc8dcd5d4e/src/main/scala/sbtlicensereport/SbtLicenseReport.scala#L84
   updateLicenses := {

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/config/AppConfig.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/config/AppConfig.scala
@@ -5,9 +5,8 @@ import org.hyperledger.identus.iam.authentication.AuthenticationConfig
 import org.hyperledger.identus.pollux.vc.jwt.*
 import org.hyperledger.identus.shared.db.DbConfig
 import org.hyperledger.identus.shared.messaging.MessagingServiceConfig
+import zio.{Config, ZIO}
 import zio.config.magnolia.*
-import zio.Config
-import zio.ZIO
 
 import java.net.URL
 import java.time.Duration

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/PresentBackgroundJobs.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/jobs/PresentBackgroundJobs.scala
@@ -25,8 +25,13 @@ import org.hyperledger.identus.pollux.core.model.presentation.Options
 import org.hyperledger.identus.pollux.core.service.{CredentialService, PresentationService}
 import org.hyperledger.identus.pollux.core.service.serdes.AnoncredCredentialProofsV1
 import org.hyperledger.identus.pollux.sdjwt.{HolderPrivateKey, IssuerPublicKey, PresentationCompact, SDJWT}
-import org.hyperledger.identus.pollux.vc.jwt.{DidResolver as JwtDidResolver, Issuer as JwtIssuer, JWT, JwtPresentation}
-import org.hyperledger.identus.pollux.vc.jwt.CredentialSchemaAndTrustedIssuersConstraint
+import org.hyperledger.identus.pollux.vc.jwt.{
+  CredentialSchemaAndTrustedIssuersConstraint,
+  DidResolver as JwtDidResolver,
+  Issuer as JwtIssuer,
+  JWT,
+  JwtPresentation
+}
 import org.hyperledger.identus.resolvers.DIDResolver
 import org.hyperledger.identus.shared.http.*
 import org.hyperledger.identus.shared.messaging

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/IssueControllerImpl.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/issue/controller/IssueControllerImpl.scala
@@ -1,7 +1,6 @@
 package org.hyperledger.identus.issue.controller
 
-import org.hyperledger.identus.agent.server.config.AppConfig
-import org.hyperledger.identus.agent.server.config.FeatureFlagConfig
+import org.hyperledger.identus.agent.server.config.{AppConfig, FeatureFlagConfig}
 import org.hyperledger.identus.agent.server.ControllerHelper
 import org.hyperledger.identus.agent.walletapi.model.PublicationState
 import org.hyperledger.identus.agent.walletapi.model.PublicationState.{Created, PublicationPending, Published}

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerServerEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerServerEndpoints.scala
@@ -147,8 +147,9 @@ case class CredentialIssuerServerEndpoints(
       }
 
   val issuerMetadataServerEndpoint: ZServerEndpoint[Any, Any] = CredentialIssuerEndpoints.issuerMetadataEndpoint
-    .zServerLogic {
-      { case (rc, didRef) => credentialIssuerController.getIssuerMetadata(rc, didRef).logTrace(rc) }
+    .zServerLogic { { case (rc, didRef) =>
+      credentialIssuerController.getIssuerMetadata(rc, didRef).logTrace(rc)
+    }
     }
 
   val all: List[ZServerEndpoint[Any, Any]] = List(

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/presentproof/controller/PresentProofControllerImpl.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/presentproof/controller/PresentProofControllerImpl.scala
@@ -1,7 +1,6 @@
 package org.hyperledger.identus.presentproof.controller
 
-import org.hyperledger.identus.agent.server.config.AppConfig
-import org.hyperledger.identus.agent.server.config.FeatureFlagConfig
+import org.hyperledger.identus.agent.server.config.{AppConfig, FeatureFlagConfig}
 import org.hyperledger.identus.agent.server.ControllerHelper
 import org.hyperledger.identus.agent.walletapi.service.ManagedDIDService
 import org.hyperledger.identus.api.http.{ErrorResponse, RequestContext}

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/presentproof/controller/http/PresentationStatus.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/presentproof/controller/http/PresentationStatus.scala
@@ -9,8 +9,6 @@ import sttp.tapir.{Schema, Validator}
 import sttp.tapir.json.zio.schemaForZioJsonValue
 import sttp.tapir.Schema.annotations.{description, encodedExample, validate}
 import zio.json.*
-import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
-import zio.json.EncoderOps
 
 final case class PresentationStatus(
     @description(annotations.presentationId.description)

--- a/cloud-agent/service/wallet-api/src/main/scala/org/hyperledger/identus/agent/walletapi/sql/JdbcDIDNonSecretStorage.scala
+++ b/cloud-agent/service/wallet-api/src/main/scala/org/hyperledger/identus/agent/walletapi/sql/JdbcDIDNonSecretStorage.scala
@@ -282,7 +282,8 @@ class JdbcDIDNonSecretStorage(xa: Transactor[ContextAwareTask], xb: Transactor[T
       case ManagedDIDKeyMeta.HD(k)   => (k.keyUsage, Some(k.keyIndex), k.keyMode, k.curve)
       case ManagedDIDKeyMeta.Rand(k) => (k.keyUsage, None, k.keyMode, k.curve)
     }
-    val cxnIO = (now: Instant) => sql"""
+    val cxnIO = (now: Instant) =>
+      sql"""
           | INSERT INTO public.prism_did_key(did, key_id, key_usage, key_index, created_at, operation_hash, key_mode, curve_name)
           | VALUES
           | (

--- a/connect/core/src/test/scala/org/hyperledger/identus/connect/core/repository/ConnectionRepositorySpecSuite.scala
+++ b/connect/core/src/test/scala/org/hyperledger/identus/connect/core/repository/ConnectionRepositorySpecSuite.scala
@@ -72,8 +72,7 @@ object ConnectionRepositorySpecSuite {
       } yield {
         assertTrue(res match
           case Exit.Failure(cause: Cause.Die) => true
-          case _                              => false
-        )
+          case _                              => false)
       }
     },
     test("getConnectionRecord correctly returns an existing record") {
@@ -213,8 +212,7 @@ object ConnectionRepositorySpecSuite {
       } yield {
         assertTrue(deleteResult match
           case Exit.Failure(cause: Cause.Die) => true
-          case _                              => false
-        ) &&
+          case _                              => false) &&
         assertTrue(records.size == 2) &&
         assertTrue(records.contains(aRecord.withWalletId(walletId))) &&
         assertTrue(records.contains(bRecord.withWalletId(walletId)))
@@ -296,8 +294,7 @@ object ConnectionRepositorySpecSuite {
       } yield {
         assertTrue(updateResult match
           case Exit.Failure(cause: Cause.Die) => true
-          case _                              => false
-        ) &&
+          case _                              => false) &&
         assertTrue(record.get.protocolState == ProtocolState.InvitationGenerated) &&
         assertTrue(updatedRecord.get.protocolState == ProtocolState.InvitationGenerated)
       }

--- a/connect/core/src/test/scala/org/hyperledger/identus/connect/core/service/ConnectionServiceImplSpec.scala
+++ b/connect/core/src/test/scala/org/hyperledger/identus/connect/core/service/ConnectionServiceImplSpec.scala
@@ -225,8 +225,7 @@ object ConnectionServiceImplSpec extends ZIOSpecDefault {
           } yield {
             assertTrue(exit match
               case Exit.Failure(Cause.Fail(_: InvalidStateForOperation, _)) => true
-              case _                                                        => false
-            )
+              case _                                                        => false)
 
           }
         }

--- a/mercury/agent-didcommx/src/main/scala/org/hyperledger/identus/mercury/model/Conversions.scala
+++ b/mercury/agent-didcommx/src/main/scala/org/hyperledger/identus/mercury/model/Conversions.scala
@@ -97,8 +97,7 @@ given Conversion[AttachmentDescriptor, XAttachment] with {
     new XAttachment.Builder(id, data)
       .format(attachment.format match
         case Some(format) => format
-        case None         => null
-      )
+        case None         => null)
       .build()
   }
 }

--- a/mercury/protocol-issue-credential/src/main/scala/org/hyperledger/identus/mercury/protocol/issuecredential/Utils.scala
+++ b/mercury/protocol-issue-credential/src/main/scala/org/hyperledger/identus/mercury/protocol/issuecredential/Utils.scala
@@ -1,8 +1,7 @@
 package org.hyperledger.identus.mercury.protocol.issuecredential
 
 import org.hyperledger.identus.mercury.model.{AttachmentDescriptor, Base64, JsonData, JwsData, LinkData}
-import zio.json.{DecoderOps, JsonDecoder}
-import zio.json.EncoderOps
+import zio.json.{DecoderOps, EncoderOps, JsonDecoder}
 
 private trait ReadAttachmentsUtils {
 

--- a/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
+++ b/pollux/core/src/main/scala/org/hyperledger/identus/pollux/core/service/PresentationServiceNotifier.scala
@@ -15,7 +15,6 @@ import org.hyperledger.identus.shared.models.*
 import zio.*
 import zio.json.*
 import zio.json.ast.Json
-import zio.URIO
 
 import java.time.Instant
 import java.util.UUID

--- a/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/CredentialServiceImplSpec.scala
+++ b/pollux/core/src/test/scala/org/hyperledger/identus/pollux/core/service/CredentialServiceImplSpec.scala
@@ -11,8 +11,11 @@ import org.hyperledger.identus.pollux.core.model.*
 import org.hyperledger.identus.pollux.core.model.error.CredentialServiceError.*
 import org.hyperledger.identus.pollux.core.model.primitives.UriString
 import org.hyperledger.identus.pollux.core.model.primitives.UriString.toUriString
-import org.hyperledger.identus.pollux.core.model.schema.{CredentialDefinition, CredentialSchemaRef}
-import org.hyperledger.identus.pollux.core.model.schema.CredentialSchemaRefType
+import org.hyperledger.identus.pollux.core.model.schema.{
+  CredentialDefinition,
+  CredentialSchemaRef,
+  CredentialSchemaRefType
+}
 import org.hyperledger.identus.pollux.core.model.IssueCredentialRecord.{ProtocolState, Role}
 import org.hyperledger.identus.pollux.core.service.uriResolvers.ResourceUrlResolver
 import org.hyperledger.identus.pollux.vc.jwt.{CredentialIssuer, JWT, JwtCredential}
@@ -227,8 +230,7 @@ object CredentialServiceImplSpec extends MockSpecDefault with CredentialServiceS
           } yield {
             assertTrue(record match
               case Exit.Failure(Cause.Die(_: UnmanagedFailureException, _)) => true
-              case _                                                        => false
-            )
+              case _                                                        => false)
           }
         }
       },
@@ -359,8 +361,7 @@ object CredentialServiceImplSpec extends MockSpecDefault with CredentialServiceS
         } yield {
           assertTrue(exit match
             case Exit.Failure(Cause.Fail(_: RecordNotFound, _)) => true
-            case _                                              => false
-          )
+            case _                                              => false)
         }
       },
       test("acceptCredentialOffer should reject unsupported `subjectId` format") {
@@ -375,8 +376,7 @@ object CredentialServiceImplSpec extends MockSpecDefault with CredentialServiceS
         } yield {
           assertTrue(record match
             case Exit.Failure(Cause.Fail(_: UnsupportedDidFormat, _)) => true
-            case _                                                    => false
-          )
+            case _                                                    => false)
         }
       },
       test("receiveCredentialRequest successfully updates the record") {
@@ -402,8 +402,7 @@ object CredentialServiceImplSpec extends MockSpecDefault with CredentialServiceS
         } yield {
           assertTrue(exit match
             case Exit.Failure(Cause.Fail(_: RecordNotFoundForThreadIdAndStates, _)) => true
-            case _                                                                  => false
-          )
+            case _                                                                  => false)
         }
       },
       test("receiveCredentialRequest is rejected for an unknown 'thid'") {
@@ -416,8 +415,7 @@ object CredentialServiceImplSpec extends MockSpecDefault with CredentialServiceS
         } yield {
           assertTrue(exit match
             case Exit.Failure(Cause.Fail(_: RecordNotFoundForThreadIdAndStates, _)) => true
-            case _                                                                  => false
-          )
+            case _                                                                  => false)
         }
       },
       test("acceptCredentialRequest successfully updates the record") {
@@ -445,8 +443,7 @@ object CredentialServiceImplSpec extends MockSpecDefault with CredentialServiceS
         } yield {
           assertTrue(exit match
             case Exit.Failure(Cause.Fail(_: RecordNotFound, _)) => true
-            case _                                              => false
-          )
+            case _                                              => false)
         }
       },
       test("receiveCredentialIssue successfully updates the record") {
@@ -480,8 +477,7 @@ object CredentialServiceImplSpec extends MockSpecDefault with CredentialServiceS
         } yield {
           assertTrue(exit match
             case Exit.Failure(Cause.Fail(_: RecordNotFoundForThreadIdAndStates, _)) => true
-            case _                                                                  => false
-          )
+            case _                                                                  => false)
         }
       }.provideSomeLayer(holderDidServiceExpectations.toLayer ++ holderManagedDIDServiceExpectations.toLayer),
       test("receiveCredentialIssue is rejected for an unknown 'thid'") {
@@ -498,8 +494,7 @@ object CredentialServiceImplSpec extends MockSpecDefault with CredentialServiceS
         } yield {
           assertTrue(exit match
             case Exit.Failure(Cause.Fail(_: RecordNotFoundForThreadIdAndStates, _)) => true
-            case _                                                                  => false
-          )
+            case _                                                                  => false)
         }
       }.provideSomeLayer(holderDidServiceExpectations.toLayer ++ holderManagedDIDServiceExpectations.toLayer),
       test("Happy flow is successfully executed") {
@@ -688,8 +683,7 @@ object CredentialServiceImplSpec extends MockSpecDefault with CredentialServiceS
             case MyBase64(value) =>
               val ba = new String(Base64.getUrlDecoder.decode(value))
               AnoncredCredential(ba).credDefId == credDefId
-            case _ => false
-          )
+            case _ => false)
         }
       }
     )

--- a/pollux/vc-jwt/src/test/scala/org/hyperledger/identus/pollux/vc/jwt/JwtPresentationTest.scala
+++ b/pollux/vc-jwt/src/test/scala/org/hyperledger/identus/pollux/vc/jwt/JwtPresentationTest.scala
@@ -1,7 +1,6 @@
 package org.hyperledger.identus.pollux.vc.jwt
 
 import zio.test.*
-import zio.test.ZIOSpecDefault
 
 object JwtPresentationTest extends ZIOSpecDefault {
   val jwt = JWT(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.2
+sbt.version=1.10.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.1")


### PR DESCRIPTION
### Description
Fix typo `scijava` in build file causing flaky `scalafmt` tasks.
For example: https://github.com/hyperledger-identus/cloud-agent/actions/runs/14996376621/job/42131525428

Debugged stack trace of a failed attempt
![Screenshot_2025-05-14_15-32-27](https://github.com/user-attachments/assets/5e27408e-c307-4417-b1f5-64a62a349558)

Also ran `scalafix`  and upgrade fix / fmt plugins.

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
