### PR TITLE
docs(README): fix broken link to Quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ System requirements can vary depending on the use case. The following are the mi
 
 #### Running locally in demo mode
 
-To run Identus locally you should follow the instructions in the [Quickstart guide](https://hyperledger.github.io/identus-docs/docs/quick-start/)
+To run Identus locally you should follow the instructions in the [Quickstart guide](https://hyperledger-identus.github.io/docs/home/quick-start)
 
 If the Cloud Agent is started successfully, all the running containers should achieve `Healthy` state, and Cloud Agent Rest API should be available at the specified port, for example:
 * `http://localhost:8080/cloud-agent` for the `issuer` instance


### PR DESCRIPTION
### Description
This PR fixes a broken link in the README that pointed to a 404 page for the Quick Start Guide.

Closes #1580 

### Checklist
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
