### PR TITLE
fix: use custom vdr scheme for vdr endpoints

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val V = new {
   val nimbusJwt = "9.37.3" // scala-steward:off //TODO: >=9.38 breaking change
   val keycloak = "23.0.7" // scala-steward:off //TODO 24.0.3 // update all quay.io/keycloak/keycloak
 
-  val vdr = "0.2.0"
+  val vdr = "0.2.1"
 }
 
 /** Dependencies */

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/Modules.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/agent/server/Modules.scala
@@ -139,19 +139,11 @@ object AppModule {
     }
   }
 
-  val vdrServiceLayer: RLayer[AppConfig, VdrService] = {
-    ZLayer.scoped[AppConfig](
-      ZIO
-        .serviceWith[AppConfig](_.agent.httpEndpoint.publicEndpointUrl)
-        .map { baseUrl =>
-          ZLayer.make[VdrService](
-            RepoModule.agentDataSourceLayer,
-            VdrServiceImpl.layer(baseUrl.toString())
-          )
-        }
-        .flatMap(_.build.map(_.get))
+  val vdrServiceLayer: RLayer[AppConfig, VdrService] =
+    ZLayer.make[VdrService](
+      RepoModule.agentDataSourceLayer,
+      VdrServiceImpl.layer
     )
-  }
 }
 
 object GrpcModule {

--- a/cloud-agent/service/vdr/src/main/scala/org/hyperledger/identus/agent/vdr/VdrService.scala
+++ b/cloud-agent/service/vdr/src/main/scala/org/hyperledger/identus/agent/vdr/VdrService.scala
@@ -72,11 +72,10 @@ class VdrServiceImpl(
 }
 
 object VdrServiceImpl {
-  def layer(publicUrl: String): RLayer[DataSource, VdrService] =
+  def layer: RLayer[DataSource, VdrService] =
     ZLayer.fromZIO {
-      val baseVdrEntryUrl = s"$publicUrl/vdr/entries"
       for
-        urlManager <- ZIO.attempt(BaseUrlManager.apply(baseVdrEntryUrl, "BaseURL"))
+        urlManager <- ZIO.attempt(BaseUrlManager.apply("vdr://", "BaseURL"))
         dbDriverDataSource <- ZIO.service[DataSource]
         drivers <- ZIO.attempt(
           Array[Driver](


### PR DESCRIPTION
### Description
Update VDR HTTP binding on the agent to use `vdr://` URL scheme

### Checklist
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
