### PR TITLE
ci: migrate Kotlin HTTP client to the new Maven Central endpoint

### DIFF
--- a/cloud-agent/client/kotlin/build.gradle.kts
+++ b/cloud-agent/client/kotlin/build.gradle.kts
@@ -101,9 +101,10 @@ if (System.getenv().containsKey("GPG_PRIVATE") && System.getenv().containsKey("G
 
 nexusPublishing {
     repositories {
+        // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
         sonatype {
-            nexusUrl.set(uri("https://oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(System.getenv("OSSRH_USERNAME"))
             password.set(System.getenv("OSSRH_PASSWORD"))
         }


### PR DESCRIPTION
### Description
- Change the Maven Central URL to publish the Kotlin HTTP client
