### PR TITLE
fix: update default value for API_KEY_AUTO_PROVISIONING to false

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ lazy val V = new {
   // [error] 	org.hyperledger.identus.pollux.core.model.schema.AnoncredSchemaTypeSpec
   // [error] 	org.hyperledger.identus.pollux.core.model.schema.CredentialSchemaSpec
 
+  val commonsLogging = "1.3.5"
   val vaultDriver = "6.2.0"
   val micrometer = "1.15.2"
 
@@ -123,6 +124,7 @@ lazy val D = new {
   val zioConfigMagnolia: ModuleID = "dev.zio" %% "zio-config-magnolia" % V.zioConfig
   val zioConfigTypesafe: ModuleID = "dev.zio" %% "zio-config-typesafe" % V.zioConfig
 
+  val commonsLogging = "commons-logging" % "commons-logging" % V.commonsLogging
   val networkntJsonSchemaValidator = "com.networknt" % "json-schema-validator" % V.jsonSchemaValidator
   val jwtZio = "com.github.jwt-scala" %% "jwt-zio-json" % V.jwtZioVersion
   val jsonCanonicalization: ModuleID = "io.github.erdtman" % "java-json-canonicalization" % "1.1"
@@ -417,7 +419,7 @@ lazy val D_CloudAgent = new {
   lazy val keyManagementDependencies: Seq[ModuleID] =
     baseDependencies ++ D.doobieDependencies ++ Seq(D.zioCatsInterop, D.zioMock, vaultDriver)
 
-  lazy val iamDependencies: Seq[ModuleID] = Seq(keycloakAuthz, D.jwtZio)
+  lazy val iamDependencies: Seq[ModuleID] = Seq(keycloakAuthz, D.jwtZio, D.commonsLogging)
 
   lazy val vdrDependencies: Seq[ModuleID] = Seq(vdr)
 

--- a/cloud-agent/service/server/src/main/resources/application.conf
+++ b/cloud-agent/service/server/src/main/resources/application.conf
@@ -130,7 +130,7 @@ agent {
             # autoProvisioning is used to enable/disable the auto-provisioning logic
             # if auto-provisioning is disabled, the entity and the wallet must be created using the REST API
             # if auto-provisioning is enabled, the entity and the wallet are created automatically when the api key is used
-            autoProvisioning = true
+            autoProvisioning = false
             autoProvisioning = ${?API_KEY_AUTO_PROVISIONING}
         }
         keycloak {

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/api/http/EndpointOutputs.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/api/http/EndpointOutputs.scala
@@ -19,6 +19,9 @@ object EndpointOutputs {
     )
   }
 
+  def basicFailuresAndForbiddenWith(extraFailures: OneOfVariant[ErrorResponse]*) =
+    basicFailuresWith((Seq(FailureVariant.unauthorized, FailureVariant.forbidden) ++ extraFailures)*)
+
   val basicFailures: EndpointOutput[ErrorResponse] = basicFailuresWith()
 
   val basicFailuresAndForbidden = basicFailuresWith(FailureVariant.unauthorized, FailureVariant.forbidden)

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/castor/controller/DIDRegistrarEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/castor/controller/DIDRegistrarEndpoints.scala
@@ -72,10 +72,7 @@ object DIDRegistrarEndpoints {
     Any
   ] = baseEndpoint.post
     .in(jsonBody[CreateManagedDidRequest])
-    .errorOut(
-      EndpointOutputs
-        .basicFailuresWith(FailureVariant.unprocessableEntity, FailureVariant.notFound, FailureVariant.forbidden)
-    )
+    .errorOut(EndpointOutputs.basicFailuresAndForbiddenWith(FailureVariant.notFound))
     .out(statusCode(StatusCode.Created).description("Created an unpublished PRISM DID"))
     .out(jsonBody[CreateManagedDIDResponse])
     .summary("Create an unpublished PRISM DID and store it in the agent's wallet")
@@ -131,15 +128,7 @@ object DIDRegistrarEndpoints {
   ] = baseEndpoint.post
     .in(DIDInput.didRefPathSegment / "updates")
     .in(jsonBody[UpdateManagedDIDRequest])
-    .errorOut(
-      EndpointOutputs
-        .basicFailuresWith(
-          FailureVariant.unprocessableEntity,
-          FailureVariant.notFound,
-          FailureVariant.conflict,
-          FailureVariant.forbidden
-        )
-    )
+    .errorOut(EndpointOutputs.basicFailuresAndForbiddenWith(FailureVariant.notFound, FailureVariant.conflict))
     .out(statusCode(StatusCode.Accepted).description("DID update operation accepted"))
     .out(jsonBody[DIDOperationResponse])
     .summary("Update DID in the agent's wallet and post update operation to the VDR")
@@ -159,10 +148,7 @@ object DIDRegistrarEndpoints {
     Any
   ] = baseEndpoint.post
     .in(DIDInput.didRefPathSegment / "deactivations")
-    .errorOut(
-      EndpointOutputs
-        .basicFailuresWith(FailureVariant.unprocessableEntity, FailureVariant.notFound, FailureVariant.forbidden)
-    )
+    .errorOut(EndpointOutputs.basicFailuresAndForbiddenWith(FailureVariant.notFound))
     .out(statusCode(StatusCode.Accepted).description("DID deactivation operation accepted"))
     .out(jsonBody[DIDOperationResponse])
     .summary("Deactivate DID in the agent's wallet and post deactivate operation to the VDR")

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/event/controller/EventEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/event/controller/EventEndpoints.scala
@@ -51,7 +51,7 @@ object EventEndpoints {
   ] = baseEndpoint.post
     .in("webhooks")
     .in(jsonBody[CreateWebhookNotification])
-    .errorOut(EndpointOutputs.basicFailuresWith(FailureVariant.forbidden, FailureVariant.conflict))
+    .errorOut(EndpointOutputs.basicFailuresAndForbiddenWith(FailureVariant.conflict))
     .out(statusCode(StatusCode.Ok).description("Webhook notification has been created successfully"))
     .out(jsonBody[WebhookNotification])
     .summary("Create wallet webhook notifications")

--- a/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerEndpoints.scala
+++ b/cloud-agent/service/server/src/main/scala/org/hyperledger/identus/oid4vci/CredentialIssuerEndpoints.scala
@@ -198,14 +198,7 @@ object CredentialIssuerEndpoints {
       statusCode(StatusCode.Created).description("Credential configuration created successfully")
     )
     .out(jsonBody[CredentialConfiguration])
-    .errorOut(
-      EndpointOutputs.basicFailuresWith(
-        FailureVariant.notFound,
-        FailureVariant.unauthorized,
-        FailureVariant.forbidden,
-        FailureVariant.conflict
-      )
-    )
+    .errorOut(EndpointOutputs.basicFailuresAndForbiddenWith(FailureVariant.notFound, FailureVariant.conflict))
     .name("createCredentialConfiguration")
     .summary("Create a new  credential configuration")
     .description(

--- a/tests/integration-tests/src/test/resources/containers/agent.yml
+++ b/tests/integration-tests/src/test/resources/containers/agent.yml
@@ -25,6 +25,7 @@ services:
     image: docker.io/hyperledgeridentus/identus-cloud-agent:${AGENT_VERSION}
     environment:
       API_KEY_ENABLED: true
+      API_KEY_AUTO_PROVISIONING: true
       API_KEY_AUTHENTICATE_AS_DEFAULT_USER: false
       PRISM_NODE_HOST: host.docker.internal
       PRISM_NODE_PORT:


### PR DESCRIPTION
### Description

- https://github.com/hyperledger-identus/cloud-agent/issues/1621
- https://github.com/hyperledger-identus/cloud-agent/issues/1627

`commons-logging` is added to fix issue when enabling keycloak.

### Checklist
- [ ] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
