### PR TITLE
fix: remove checksum bypass and pin java-multibase to v1.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       JAVA_TOOL_OPTIONS: -Djava.net.preferIPv4Stack=true
       SBT_OPTS: -Xmx2G
-      COURSIER_CHECKSUMS: "none" # JitPack serves stale .sha1 for java-multibase
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,8 +17,6 @@ defaults:
 permissions:
   contents: read
 
-env:
-
 jobs:
   run-integration-tests-neoprism:
     name: "Run integration tests (neoprism)"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,6 @@ permissions:
   contents: read
 
 env:
-  COURSIER_CHECKSUMS: "none" # JitPack serves stale .sha1 for java-multibase
 
 jobs:
   run-integration-tests-neoprism:

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -24,7 +24,6 @@ env:
   GITHUB_ACTOR: ${{ github.actor }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   DOCKER_API_VERSION: "1.44"
-  COURSIER_CHECKSUMS: "none" # JitPack serves stale .sha1 for java-multibase
 
 jobs:
   run-e2e-tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,6 @@ jobs:
       pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      COURSIER_CHECKSUMS: "none" # JitPack serves stale .sha1 for java-multibase
       SBT_OPTS: -Xmx2G
       DOCKER_API_VERSION: "1.44"
       TESTCONTAINERS_RYUK_DISABLED: true

--- a/build.sbt
+++ b/build.sbt
@@ -18,10 +18,6 @@ inThisBuild(
 // Fixes a bug with concurrent packages download from GitHub registry
 Global / concurrentRestrictions += Tags.limit(Tags.Network, 1)
 
-// JitPack serves stale .sha1 for java-multibase, causing Coursier checksum mismatch.
-// Set COURSIER_CHECKSUMS=none in CI to disable validation (local builds unaffected).
-lazy val disableCoursierChecksums = sys.env.getOrElse("COURSIER_CHECKSUMS", "") == "none"
-
 coverageDataDir := target.value / "coverage"
 coberturaFile := target.value / "coverage" / "coverage-report" / "cobertura.xml"
 coverageExcludedPackages := "(?i).*proto.*;.*grpc.*;.*scalapb.*;.*protobuf.*;.*generated.*"
@@ -149,6 +145,9 @@ lazy val D = new {
   // https://mvnrepository.com/artifact/org.didcommx/didcomm/0.3.2
   val didcommx: ModuleID = "org.didcommx" % "didcomm" % "0.3.2"
   val peerDidcommx: ModuleID = "org.didcommx" % "peerdid" % "0.5.0"
+  // peerdid depends on java-multibase (transitive, JitPack only). v1.1.0 has stale .sha1 metadata,
+  // so we force v1.1.1 which has consistent JitPack checksums. Remove once peerdid upgrades.
+  val javaMultibase: ModuleID = "com.github.multiformats" % "java-multibase" % "v1.1.1"
   val didScala: ModuleID = "app.fmgp" %% "did" % "0.0.0+113-61efa271-SNAPSHOT"
 
   val nimbusJwt: ModuleID = "com.nimbusds" % "nimbus-jose-jwt" % V.nimbusJwt
@@ -461,10 +460,7 @@ val commonSetttings = Seq(
 lazy val commonConfigure: Project => Project = _.settings(
   Compile / scalacOptions += "-Yimports:java.lang,scala,scala.Predef,org.hyperledger.identus.Predef",
   Test / scalacOptions -= "-Yimports:java.lang,scala,scala.Predef,org.hyperledger.identus.Predef",
-  csrConfiguration := {
-    val conf = csrConfiguration.value
-    if (disableCoursierChecksums) conf.withChecksums(Vector.empty) else conf
-  },
+  dependencyOverrides += D.javaMultibase,
 ).dependsOn(predef)
 
 // #####################

--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ lazy val D = new {
   val didcommx: ModuleID = "org.didcommx" % "didcomm" % "0.3.2"
   val peerDidcommx: ModuleID = "org.didcommx" % "peerdid" % "0.5.0"
   // peerdid depends on java-multibase (transitive, JitPack only). v1.1.0 has stale .sha1 metadata,
-  // so we force v1.1.1 which has consistent JitPack checksums. Remove once peerdid upgrades.
+  // so we force v1.1.1 which currently has consistent JitPack checksums. Remove once peerdid upgrades.
   val javaMultibase: ModuleID = "com.github.multiformats" % "java-multibase" % "v1.1.1"
   val didScala: ModuleID = "app.fmgp" %% "did" % "0.0.0+113-61efa271-SNAPSHOT"
 


### PR DESCRIPTION
### Description

Fixes #1739 by replacing the CI-wide checksum bypass with a targeted dependency pin.

JitPack rebuilt `java-multibase:v1.1.0` but left stale `.sha1` metadata, causing Coursier checksum mismatches. The previous mitigation set `COURSIER_CHECKSUMS=none` in all CI workflows and conditionally disabled checksums in `build.sbt`. This had two downsides:
1. It disabled checksum validation for **all** artifacts in CI, not just the bad JitPack one.
2. It leaked CI-specific hacks into `build.sbt`.

This PR implements a cleaner fix:
- Pins the transitive `java-multibase` dependency to `v1.1.1` via `dependencyOverrides` in `commonConfigure`. JitPack serves consistent `.sha1` metadata for this version.
- Removes `COURSIER_CHECKSUMS=none` from all four CI workflow files.
- Removes the conditional `csrConfiguration` logic from `build.sbt`.

Local and CI builds now keep full Coursier checksum validation enabled while resolving the `peerdid` → `java-multibase` transitive issue.

### Alternatives Considered (optional)

- **Wait for upstream** (`peerdid` 0.5.x to drop `java-multibase`): The JitPack v1.1.0 metadata may never be fixed, and `peerdid` releases are on an independent timeline. Unblocking CI now is worth the one-line override.
- **Remove JitPack resolver**: `java-multibase` is not published to Maven Central; JitPack is the only source. Leaving the resolver in place is required.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)