### PR TITLE
docs: add Docusaurus docs note in docs/README.md (supersedes #1446)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,8 @@ docker-compose -f docs/docker-compose.yml up
 ```
 
 - OpenAPI specifications doc is available *localhost:8081*
+
+## Docusaurus docs
+
+These `docs/docusaurus` are built as part of the [Identus Docs](https://github.com/hyperledger-identus/docs) repository.
+The over-arching configuration and setup needed to build the full docs are held there (these docs are loaded in as a git submodule).


### PR DESCRIPTION
## Summary

- Adds a short section to `docs/README.md` pointing readers to the [hyperledger-identus/docs](https://github.com/hyperledger-identus/docs) repo, which holds the over-arching Docusaurus configuration and includes `docs/docusaurus` as a git submodule.
- Fixes a small typo ("heald" → "held") from the original change.
- Refreshes the link from the legacy `hyperledger/identus-docs` repo to the current `hyperledger-identus/docs` repo.

## Background

This PR supersedes #1446 (originally opened by @mixmix on 2024-11-18, approved 2025-03-20). That PR has been sitting open with merge conflicts; we are bringing the change forward on a fresh branch from `main` so it can finally land. Once this merges, #1446 can be closed.

## Linked PR

Closes #1446

## Test plan

- [ ] Visual review of rendered Markdown on GitHub
- [ ] Confirm link to `hyperledger-identus/docs` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)