### PR TITLE
ci: harden release workflows and pin npm install

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -199,7 +199,12 @@ jobs:
           AGENT_VERSION: ${{ steps.build_local_cloud_agent.outputs.agent_version }}
         run: |
           ./docker/run.sh "$AGENT_VERSION"
-          npm i
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --package-lock-only
+            npm ci
+          fi
           npm test
           ./docker/stop.sh
 

--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -129,23 +129,21 @@ jobs:
           RELEASE_TAG: ${{ github.event.inputs.releaseTag }}
         run: |
           set -euo pipefail
-          case "$REVISION" in
-            # allow alphanumerics, dot, dash, underscore
-            ''|*[!A-Za-z0-9._-]*)
-              echo "Invalid revision value"; exit 1 ;;
-          esac
-          case "${RELEASE_TAG:-}" in
-            # allow empty or safe tag characters
-            ''|*[!A-Za-z0-9._-]*)
-              if [ -n "${RELEASE_TAG:-}" ]; then
-                echo "Invalid releaseTag value"; exit 1
-              fi
-              ;;
-          esac
-
           if [ -z "${RELEASE_TAG:-}" ]; then
+              # Revision-based release: validate and use REVISION.
+              case "$REVISION" in
+                # allow alphanumerics, dot, dash, underscore
+                ''|*[!A-Za-z0-9._-]*)
+                  echo "Invalid revision value"; exit 1 ;;
+              esac
               echo "VERSION_TAG=cloud-agent-v${REVISION}" >> "$GITHUB_ENV"
           else
+              # Tag-based release: validate and use RELEASE_TAG.
+              case "$RELEASE_TAG" in
+                # allow alphanumerics, dot, dash, underscore
+                *[!A-Za-z0-9._-]*)
+                  echo "Invalid releaseTag value"; exit 1 ;;
+              esac
               echo "VERSION_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
           fi
 

--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -57,13 +57,19 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4.4.0
         with:
-          node-version: "lts/*"
+          node-version: "22.16.0"
           registry-url: "https://registry.npmjs.org"
           scope: "@hyperledger"
 
       # Ensure npm version ≥ 11.5.1 for Trusted Publishing
       - name: Upgrade npm
-        run: npm install -g npm@^11.5.1
+        run: |
+          URL="https://registry.npmjs.org/npm/-/npm-11.5.1.tgz"
+          EXPECTED_HASH="f4c82fbff74154f73bd5ce5a2b749700d55eaddebda97b16076bf7033040de34"
+          curl -sSfL "$URL" -o npm.tgz
+          echo "$EXPECTED_HASH npm.tgz" | sha256sum -c -
+          npm install -g npm.tgz
+          rm npm.tgz
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
@@ -84,13 +90,30 @@ jobs:
       - name: Rename OpenAPI specification
         if: ${{ !inputs.releaseTag }}
         working-directory: cloud-agent/service/api/http
+        env:
+          REVISION: ${{ inputs.revision }}
         run: |
-          mv cloud-agent-openapi-spec-${{ inputs.revision }}.yaml cloud-agent-openapi-spec.yaml
+          set -euo pipefail
+          case "$REVISION" in
+            # allow alphanumerics, dot, dash, underscore
+            ''|*[!A-Za-z0-9._-]*)
+              echo "Invalid revision value"; exit 1 ;;
+          esac
+          mv "cloud-agent-openapi-spec-${REVISION}.yaml" cloud-agent-openapi-spec.yaml
 
       - name: Set revision version
         if: ${{ !inputs.releaseTag }}
         working-directory: cloud-agent/client/generator
-        run: yarn version --new-version ${{ inputs.revision }} --no-git-tag-version
+        env:
+          REVISION: ${{ inputs.revision }}
+        run: |
+          set -euo pipefail
+          case "$REVISION" in
+            # allow alphanumerics, dot, dash, underscore
+            ''|*[!A-Za-z0-9._-]*)
+              echo "Invalid revision value"; exit 1 ;;
+          esac
+          yarn version --new-version "$REVISION" --no-git-tag-version
 
       - name: Install generator dependencies
         working-directory: cloud-agent/client/generator
@@ -101,11 +124,29 @@ jobs:
         run: yarn generate:all
 
       - name: Set version for clients
+        env:
+          REVISION: ${{ inputs.revision }}
+          RELEASE_TAG: ${{ github.event.inputs.releaseTag }}
         run: |
-          if [ -z "${{ github.event.inputs.releaseTag }}" ]; then
-              echo "VERSION_TAG=cloud-agent-v${{ inputs.revision }}" >> $GITHUB_ENV
+          set -euo pipefail
+          case "$REVISION" in
+            # allow alphanumerics, dot, dash, underscore
+            ''|*[!A-Za-z0-9._-]*)
+              echo "Invalid revision value"; exit 1 ;;
+          esac
+          case "${RELEASE_TAG:-}" in
+            # allow empty or safe tag characters
+            ''|*[!A-Za-z0-9._-]*)
+              if [ -n "${RELEASE_TAG:-}" ]; then
+                echo "Invalid releaseTag value"; exit 1
+              fi
+              ;;
+          esac
+
+          if [ -z "${RELEASE_TAG:-}" ]; then
+              echo "VERSION_TAG=cloud-agent-v${REVISION}" >> "$GITHUB_ENV"
           else
-              echo "VERSION_TAG=${{ github.event.inputs.releaseTag }}" >> $GITHUB_ENV
+              echo "VERSION_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
           fi
 
       # The npm publish step uses Trusted Publisher via OIDC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.IDENTUS_CI }}
           DOCKERHUB_ORG: ${{ vars.DOCKERHUB_ORG }}
         run: |
-          npm install
+          npm ci
           npx semantic-release
 
       - name: Get release version


### PR DESCRIPTION
## Summary

Picks up the stale [#1684](https://github.com/hyperledger-identus/cloud-agent/pull/1684) by @mineme0110 (idle since the 2025-12 `CHANGES_REQUESTED` review) and rebases its changes onto current `main`. None of the hardenings are on `main` yet, so the PR is still relevant.

### What changes

- **`npm ci` everywhere** ([integration-tests.yml](.github/workflows/integration-tests.yml), [release.yml](.github/workflows/release.yml)) — CI uses the committed lockfile instead of resolving versions afresh. In `tests/didcomm-tests` (no lockfile checked in) we fall back to `npm install --package-lock-only && npm ci`, addressing @amagyar-iohk's review comment about pinned versions needing `npm ci`.
- **Pin Node.js to `22.16.0`** in [release-clients.yml](.github/workflows/release-clients.yml) (was `lts/*`) for reproducibility.
- **Verify the npm 11.5.1 tarball via SHA-256** before `npm install -g` — defends against registry tampering. Hash verified against the live registry today.
- **Input validation** for the `revision` and `releaseTag` workflow inputs in [release-clients.yml](.github/workflows/release-clients.yml) — only `[A-Za-z0-9._-]` allowed before they're interpolated into shell commands. Closes the shell-injection surface SonarCloud flagged.

### Verification

- All three YAMLs parse cleanly.
- Tested the `case` pattern against realistic revisions and a battery of injection attempts (`; rm -rf /`, backticks, `$(...)`, `&& ...`) — all rejected.
- npm 11.5.1 tarball SHA-256 confirmed against the registry.

Original-author attribution preserved via `Co-authored-by: Shailesh Patil`.

## Test plan

- [ ] CI green (lint, unit, integration, perf, dependency-review, SonarCloud)
- [ ] After merge, close [#1684](https://github.com/hyperledger-identus/cloud-agent/pull/1684) as superseded

🤖 Generated with [Claude Code](https://claude.com/claude-code)