### PR TITLE
fix(tests): pin published snapshot and drop invalid github packages repo

### DIFF
--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -23,13 +23,6 @@ repositories {
     maven {
         url = uri("https://central.sonatype.com/repository/maven-snapshots/")
     }
-    maven {
-        url = uri("https://maven.pkg.github.com/hyperledger-identus/cloud-agent-client/")
-        credentials {
-            username = System.getenv("GITHUB_ACTOR")
-            password = System.getenv("GITHUB_TOKEN")
-        }
-    }
 }
 
 dependencies {
@@ -39,7 +32,7 @@ dependencies {
     // RestAPI client
     // locally published from cloud-agent/client/kotlin
     //testImplementation("org.hyperledger.identus:cloud-agent-client:0.0.1-SNAPSHOT")
-    testImplementation("org.hyperledger.identus:cloud-agent-client:2.1.1-0dfbcd7-SNAPSHOT")
+    testImplementation("org.hyperledger.identus:cloud-agent-client:2.1.1-e1e8be1-SNAPSHOT")
     // Test helpers library
     testImplementation("io.iohk.atala:atala-automation:0.4.0")
     // Hoplite for configuration

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -21,20 +21,14 @@ repositories {
     mavenCentral()
 
     maven {
-        url = uri("https://maven.pkg.github.com/hyperledger/identus-cloud-agent/")
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+    }
+    maven {
+        url = uri("https://maven.pkg.github.com/hyperledger-identus/cloud-agent-client/")
         credentials {
             username = System.getenv("GITHUB_ACTOR")
             password = System.getenv("GITHUB_TOKEN")
         }
-    }
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-    maven {
-        url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-    }
-    maven {
-        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
     }
 }
 


### PR DESCRIPTION
Fixes the integration test CI failure (`Could not find org.hyperledger.identus:cloud-agent-client:2.1.1-0dfbcd7-SNAPSHOT`). This fails for all PRs that touch the integration tests.

### Root cause
The previous change had two bugs in `tests/integration-tests/build.gradle.kts`:

1. **Invalid GitHub Packages URL.** It pointed to `https://maven.pkg.github.com/hyperledger-identus/cloud-agent-client/`, but `cloud-agent-client` is a Maven artifact name, not a GitHub repository — the actual repository hosting the package is `hyperledger-identus/cloud-agent`. The Kotlin client has also been migrated to Sonatype Central snapshots (see branch `1604-migrate-publishing-of-the-cloud-agent-http-client-in-kotlin-to-the-new-maven-central-endpoint`), so GitHub Packages is no longer the source for snapshots.
2. **Pinned version does not exist.** The version `2.1.1-0dfbcd7-SNAPSHOT` was never published: the short hash `0dfbcd7` does not correspond to any commit in the repository, and no such snapshot is in the Sonatype Central snapshots repository.

### Changes
- Drop the `https://maven.pkg.github.com/hyperledger-identus/cloud-agent-client/` block from the Gradle `repositories` (the URL was wrong and the package is no longer published there).
- Pin the dependency to `2.1.1-e1e8be1-SNAPSHOT`, which is the latest snapshot published to Sonatype Central and corresponds to commit `e1e8be1e` on `main` ("fix(docs): correct glossary link paths in connectionless present-proof").

### Follow-up
The version string is still hand-pinned. A future improvement would be to either (a) inject the version from a workflow output / generate it from `GITHUB_SHA` so PRs always consume the latest published snapshot, or (b) add a `gradle publishToMavenLocal` step in the integration test workflow so each PR builds and consumes its own client. Both are out of scope for this fix.