### PR TITLE
build: update Apollo to 1.8.8

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -561,4 +561,3 @@ none specified | []() | org.hyperledger # vdr-neoprism_3 # 2.2.0 | <notextile></
 none specified | []() | org.hyperledger # vdr-prism-node_3 # 2.2.0 | <notextile></notextile>
 none specified | []() | org.hyperledger # vdr-proxy_3 # 2.2.0 | <notextile></notextile>
 none specified | []() | [org.webjars # swagger-ui # 5.17.14](https://www.webjars.org) | <notextile></notextile>
-

--- a/build.sbt
+++ b/build.sbt
@@ -183,12 +183,18 @@ lazy val D = new {
   val monocleMacro: ModuleID = "dev.optics" %% "monocle-macro" % V.monocle % Test
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19" % Test
 
-  val apollo = Seq( // TODO remove exclude after fix https://github.com/hyperledger/identus-apollo/issues/192
+  private val apolloJvm: ModuleID =
     "org.hyperledger.identus" % "apollo-jvm" % V.apollo exclude (
       "net.jcip",
       "jcip-annotations"
-    ), // Exclude because of license
-    "com.github.stephenc.jcip" % "jcip-annotations" % "1.0-1" % Runtime, // Replace for net.jcip % jcip-annotations"
+    ) // bitcoinj-core still pulls net.jcip:jcip-annotations transitively
+
+  private val jcipAnnotationsRuntime: ModuleID =
+    "com.github.stephenc.jcip" % "jcip-annotations" % "1.0-1" % Runtime
+
+  val apollo = Seq(
+    apolloJvm,
+    jcipAnnotationsRuntime // License-compatible replacement for net.jcip:jcip-annotations
   )
 
   // LIST of Dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val V = new {
   val jwtZioVersion = "11.0.2"
   val zioPreludeVersion = "1.0.0-RC44"
 
-  val apollo = "1.8.7"
+  val apollo = "1.8.8"
 
   val jsonSchemaValidator = "1.3.2" // scala-steward:off //TODO 1.3.2 need to fix:
   // [error] 	org.hyperledger.identus.pollux.core.model.schema.AnoncredSchemaTypeSpec

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val V = new {
   val jwtZioVersion = "11.0.2"
   val zioPreludeVersion = "1.0.0-RC44"
 
-  val apollo = "1.3.5"
+  val apollo = "1.8.7"
 
   val jsonSchemaValidator = "1.3.2" // scala-steward:off //TODO 1.3.2 need to fix:
   // [error] 	org.hyperledger.identus.pollux.core.model.schema.AnoncredSchemaTypeSpec
@@ -184,7 +184,7 @@ lazy val D = new {
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19" % Test
 
   val apollo = Seq( // TODO remove exclude after fix https://github.com/hyperledger/identus-apollo/issues/192
-    "io.iohk.atala.prism.apollo" % "apollo-jvm" % V.apollo exclude (
+    "org.hyperledger.identus" % "apollo-jvm" % V.apollo exclude (
       "net.jcip",
       "jcip-annotations"
     ), // Exclude because of license

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -64,6 +64,9 @@ tasks.test {
     finalizedBy("aggregate", "reports")
     jvmArgs("-Dlog4j2.disable.jmx=true")
     testLogging.showStandardStreams = true
+    systemProperty("AGENT_VERSION", System.getenv("AGENT_VERSION") ?: "")
+    systemProperty("PRISM_NODE_VERSION", System.getenv("PRISM_NODE_VERSION") ?: "")
+    systemProperty("NEOPRISM_VERSION", System.getenv("NEOPRISM_VERSION") ?: "")
     systemProperty("cucumber.filter.tags", System.getProperty("cucumber.filter.tags"))
     // Since the test runs on host and system-unter-test runs in containers,
     // We need to make the test on host resolves host.docker.internal same as the containerized services,

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.9.21"
+    kotlin("jvm") version "2.1.20"
     idea
     java
     id("net.serenity-bdd.serenity-gradle-plugin") version "4.0.46"

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -42,9 +42,9 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:2.0.3")
     // Crypto
     testImplementation("com.nimbusds:nimbus-jose-jwt:9.40")
-    testImplementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
+    testImplementation("org.bouncycastle:bcprov-jdk18on:1.80")
     testImplementation("com.google.crypto.tink:tink:1.13.0")
-    testImplementation("org.hyperledger.identus:apollo-jvm:1.8.7")
+    testImplementation("org.hyperledger.identus:apollo-jvm:1.8.8")
     // OID4VCI
     testImplementation("org.htmlunit:htmlunit:4.3.0")
     testImplementation("eu.europa.ec.eudi:eudi-lib-jvm-openid4vci-kt:0.4.1")

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     testImplementation("com.nimbusds:nimbus-jose-jwt:9.40")
     testImplementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
     testImplementation("com.google.crypto.tink:tink:1.13.0")
-    testImplementation("io.iohk.atala.prism.apollo:apollo-jvm:1.3.4")
+    testImplementation("org.hyperledger.identus:apollo-jvm:1.8.7")
     // OID4VCI
     testImplementation("org.htmlunit:htmlunit:4.3.0")
     testImplementation("eu.europa.ec.eudi:eudi-lib-jvm-openid4vci-kt:0.4.1")

--- a/tests/integration-tests/src/test/resources/containers/agent.yml
+++ b/tests/integration-tests/src/test/resources/containers/agent.yml
@@ -20,7 +20,7 @@ services:
 
   # Open Enterprise Agent
   identus-cloud-agent:
-    image: docker.io/hyperledgeridentus/identus-cloud-agent:2.1.1-SNAPSHOT
+    image: docker.io/hyperledgeridentus/identus-cloud-agent:${AGENT_VERSION:-2.1.1-SNAPSHOT}
     pull_policy: if_not_present
     environment:
       API_KEY_ENABLED: true


### PR DESCRIPTION
Updates cloud-agent to Apollo 1.8.8 and keeps the Apollo JVM dependency on the current published group.

Changes:
- bump Apollo to 1.8.8 in sbt
- keep apollo-jvm on org.hyperledger.identus
- align integration-test Apollo dependency to 1.8.8
- align integration-test Bouncy Castle dependency to bcprov-jdk18on:1.80, matching Apollo 1.8.8 transitive dependencies

Validation:
- Maven Central serves org.hyperledger.identus:apollo-jvm:1.8.8
- sbt update
- sbt compile
- ./gradlew dependencyInsight --configuration testRuntimeClasspath --dependency org.hyperledger.identus:apollo-jvm
- ./gradlew dependencyInsight --configuration testRuntimeClasspath --dependency org.bouncycastle:bcprov-jdk18on
- ./gradlew testClasses