### PR TITLE
docs: fix AnonCreds present-proof example (proofs field + full registry URLs)

### DIFF
--- a/docs/docusaurus/credentials/didcomm/present-proof.md
+++ b/docs/docusaurus/credentials/didcomm/present-proof.md
@@ -89,13 +89,14 @@ curl -X 'POST' 'http://localhost:8070/cloud-agent/present-proof/presentations' \
  -H "apikey: $API_KEY" \
   -d '{
         "connectionId": "872ddfa9-4115-46c2-8a1b-22c24c7431d7",
+        "proofs": [],
         "anoncredPresentationRequest": {
           "requested_attributes": {
             "attribute1": {
               "name": "Attribute 1",
               "restrictions": [
                 {
-                  "cred_def_id": "credential_definition_id_of_attribute1"
+                  "cred_def_id": "http://localhost:8070/cloud-agent/credential-definition-registry/definitions/<credential-definition-guid>/definition"
                 }
               ],
               "non_revoked": {
@@ -111,7 +112,7 @@ curl -X 'POST' 'http://localhost:8070/cloud-agent/present-proof/presentations' \
               "p_value": 18,
               "restrictions": [
                 {
-                  "schema_id": "schema_id_of_predicate1"
+                  "schema_id": "http://localhost:8070/cloud-agent/schema-registry/schemas/<schema-guid>/schema"
                 }
               ],
               "non_revoked": {


### PR DESCRIPTION
### Description

The AnonCreds present-proof example in this tutorial is missing the required `proofs` field, so following it returns `400 RequestBodyDecodingFailure (missing at 'proofs')`. It also uses bare placeholder IDs for `cred_def_id` and `schema_id`, but the API actually expects the full registry URLs.

This PR fixes the AnonCreds `POST /present-proof/presentations` example:

- Adds the required `"proofs": []` field (`proofs` is a non-optional `Seq` in `RequestPresentationInput`, so it has to be there).
- Changes `cred_def_id` to the full URL: `.../credential-definition-registry/definitions/{guid}/definition`.
- Changes `schema_id` to the full URL: `.../schema-registry/schemas/{guid}/schema`.

Addresses hyperledger-identus/docs#232

### Alternatives Considered (optional)

N/A — documentation-only fix to match the actual API behavior.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/cloud-agent/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A (documentation only)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (documentation only)
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
