### PR TITLE
fix: logout from GHCR before integration tests to allow anonymous pull of keycloak-plugins image

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           export DOCKER_API_VERSION=1.44
           export DOCKER_HOST=unix:///var/run/docker.sock
+          docker logout ghcr.io  # GITHUB_TOKEN is scoped to hyperledger-identus; keycloak-plugins image is under hyperledger org, so pull anonymously
           ./gradlew test --tests "IntegrationTestsRunner" -Dcucumber.filter.tags="not @vdr_memory_and_db and not @vdr_ledger"
 
       - name: Make report of integration tests (neoprism)
@@ -289,6 +290,7 @@ jobs:
         run: |
           export DOCKER_API_VERSION=1.44
           export DOCKER_HOST=unix:///var/run/docker.sock
+          docker logout ghcr.io  # GITHUB_TOKEN is scoped to hyperledger-identus; keycloak-plugins image is under hyperledger org, so pull anonymously
           ./gradlew test --tests "IntegrationTestsRunner" -Dcucumber.filter.tags="@vdr_ledger"
 
       - name: Make report of integration tests (prism-node)


### PR DESCRIPTION
The `GITHUB_TOKEN` used in `docker/login-action` is scoped to the `hyperledger-identus` org, but the keycloak-plugins image lives under the `hyperledger` org (`ghcr.io/hyperledger/identus-keycloak-plugins:0.2.0`). Docker's authenticated session fails on cross-org pulls with "manifest unknown" even though the image is public and pullable anonymously.

Logging out of GHCR before the Gradle test step allows Testcontainers to pull the image anonymously, which succeeds since the package is public.

This is a pre-existing infra issue: the GHCR package was published under the `hyperledger` org when the repo lived there, and was not transferred when the repo moved to `hyperledger-identus`.
