### PR TITLE
fix(ci): remove GHCR docker login from integration tests to fix keycloak-plugins image pull

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,13 +51,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: hyperledger-bot
-          password: ${{ secrets.GITHUB_TOKEN }}
-
+      # NOTE: do NOT `docker login` to ghcr.io here. The job has no `packages: read`
+      # permission, no sbt GitHub-Packages resolver, and the only ghcr.io image used
+      # (ghcr.io/hyperledger/identus-keycloak-plugins) is public. Authenticating with
+      # the repo-scoped GITHUB_TOKEN makes GHCR return "manifest unknown" for that
+      # cross-repo public image (docker/login-action >= v4 persists creds in a way
+      # docker-compose picks up). Anonymous pull works.
       - name: Install Compose
         uses: ndeloof/install-compose-action@4a33bc31f327b8231c4f343f6fba704fedc0fa23 # v0.0.1
         with:
@@ -240,13 +239,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: hyperledger-bot
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Compose
         uses: ndeloof/install-compose-action@4a33bc31f327b8231c4f343f6fba704fedc0fa23 # v0.0.1


### PR DESCRIPTION
## Problem

Integration-test jobs (`Run integration tests (neoprism)` / `(prism-node)`) have been failing at container startup on every PR since Jul 13:

```
tc.docker -  keycloak Pulling
tc.docker -  manifest unknown
IntegrationTestsRunner > classMethod FAILED
```

The image that fails to load is `ghcr.io/hyperledger/identus-keycloak-plugins:0.2.0`.

## Root cause

This is a regression introduced by #1829, which bumped `docker/login-action` **v3.6.0 → v4.4.0** (the v3→v4 major bump). Last green run: **Jul 6**; all runs red since **Jul 13** — exact boundary.

The image itself is **public and valid** (verified anonymously: tag `0.2.0` resolves to a multi-arch OCI index, HTTP 200). The failure is purely an auth artifact:

- The workflow logs into `ghcr.io` with the repo-scoped `GITHUB_TOKEN` (scoped to `hyperledger-identus/cloud-agent`).
- Under `docker/login-action` v4.x, those credentials are picked up by `docker compose` and sent when pulling the keycloak-plugins image, which lives in a **different repo's** GHCR package namespace.
- GHCR returns **`manifest unknown`** for an authenticated-but-unauthorized token and does **not** fall back to anonymous access. Docker does not retry anonymously.
- On Jul 6 (v3.6.0) the *same* login succeeded and the image pulled fine, confirming the regression is the login-action version, not the image.

## Why the login step is unnecessary (and safe to remove)

- The job permissions are only `checks: write` + `pull-requests: write` — **no `packages: read`**, so the token cannot read any private package anyway.
- There is **no sbt GitHub-Packages resolver** (the only one — `anoncreds-rs` — is commented out in `build.sbt:3`); dependencies resolve from Maven Central / jitpack / local `.m2`.
- The **only** `ghcr.io` image among all test containers is `identus-keycloak-plugins`, which is public and pulls anonymously.
- The cloud-agent image is built locally via `publishLocal`; its base images come from Docker Hub.

## Fix

Remove the `docker/login-action` (ghcr.io) step from both integration-test jobs. Anonymous pull of the public keycloak-plugins image then succeeds.

## Why the previous attempt didn't work

#1842 tried `docker logout ghcr.io` before the tests. I checked its run: logout printed `Removing login credentials for ghcr.io` yet the pull still returned `manifest unknown` — v4.x credential state survives a plain logout, so that approach is unreliable.

## Alternatives considered

- Pin `docker/login-action` back to v3.6.0 — restores prior behavior but leaves a useless login that will re-break on the next dependabot bump.
- Add `packages: read` + grant the cloud-agent token access to the `identus-keycloak-plugins` package (org-level setting) — heavier, outside this repo.

Removing the step is the cleanest, permanent fix.

## Validation

- [x] YAML validated
- [ ] `Integration tests (neoprism)` and `(prism-node)` get past container startup (keycloak pulls anonymously) and proceed to run tests