### PR TITLE
fix(ci): point keycloak image at new working namespace (unblock integration tests)

### DIFF
--- a/examples/.nickel/stack.ncl
+++ b/examples/.nickel/stack.ncl
@@ -47,7 +47,7 @@ in
             |> std.record.remove "image"
           )
           & {
-            image = "ghcr.io/hyperledger/identus-keycloak-plugins:%{V.identusKeycloak}",
+            image = "ghcr.io/hyperledger-identus/keycloak-plugins:%{V.identusKeycloak}",
             ports = ["%{std.to_string args.port}:8080"],
             environment = args.extraEnvs
           },

--- a/examples/st-oid4vci/compose.yaml
+++ b/examples/st-oid4vci/compose.yaml
@@ -107,7 +107,7 @@ services:
       IDENTUS_URL: http://caddy-issuer:8080/cloud-agent
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-    image: ghcr.io/hyperledger/identus-keycloak-plugins:0.2.0
+    image: ghcr.io/hyperledger-identus/keycloak-plugins:0.2.1
     ports:
     - 9980:8080
     restart: always

--- a/tests/integration-tests/src/test/resources/containers/keycloak-oid4vci.yml
+++ b/tests/integration-tests/src/test/resources/containers/keycloak-oid4vci.yml
@@ -1,6 +1,6 @@
 services:
   keycloak:
-    image: ghcr.io/hyperledger/identus-keycloak-plugins:0.2.0
+    image: ghcr.io/hyperledger-identus/keycloak-plugins:0.2.1
     pull_policy: if_not_present
     ports:
       - "${KEYCLOAK_HTTP_PORT}:8080"


### PR DESCRIPTION
## Problem

Integration tests have been failing at startup on every PR since mid-July:

\`\`\`
tc.docker -  keycloak Pulling
tc.docker -  manifest unknown
IntegrationTestsRunner > classMethod FAILED
\`\`\`

The referenced image \`ghcr.io/hyperledger/identus-keycloak-plugins:0.2.0\` is broken on GHCR — orphaned under the legacy \`hyperledger\` org, its platform manifests were garbage-collected, so \`docker pull\` returns \`manifest unknown\`.

## Fix

The image has been republished under the **repo-linked namespace** \`ghcr.io/hyperledger-identus/keycloak-plugins\` (auto-linked to the [keycloak-plugins](https://github.com/hyperledger-identus/keycloak-plugins) repo, so it can't be orphaned/GC'd again), and **0.2.1** is published there. Verified anonymously:

\`\`\`
$ docker pull ghcr.io/hyperledger-identus/keycloak-plugins:0.2.1
Status: Downloaded newer image ...   # index 200, arm64+amd64 manifests OK
\`\`\`

This PR repoints the three references to the new namespace + \`0.2.1\`:
- \`tests/integration-tests/src/test/resources/containers/keycloak-oid4vci.yml\` (the one the CI uses)
- \`examples/st-oid4vci/compose.yaml\`
- \`examples/.nickel/stack.ncl\`

## Related
- keycloak-plugins [#18](https://github.com/hyperledger-identus/keycloak-plugins/pull/18) — migrated the Docker image to the repo-linked namespace
- keycloak-plugins [#20](https://github.com/hyperledger-identus/keycloak-plugins/pull/20) — dropped Maven publishing; the \`0.2.1\` image was published by the subsequent release run

Note: the keycloak-plugins \`release.yml\` failed at its final step (pushing the release commit/tag to the signature-protected \`main\`) — but the image was already pushed before that, so \`0.2.1\` is available. The release-bookkeeping issue is tracked separately and doesn't affect this image.