### PR TITLE
fix(examples): bump keycloak-plugins Nickel stack version to 0.2.1

### DIFF
--- a/examples/.nickel/versions.ncl
+++ b/examples/.nickel/versions.ncl
@@ -2,7 +2,7 @@
   # identus
   agent = "2.0.0",
   node = "2.6.0",
-  identusKeycloak = "0.2.0",
+  identusKeycloak = "0.2.1",
   # 3rd party
   caddy = "2.7.6-alpine",
   mockServer = "5.15.0",


### PR DESCRIPTION
## Summary

Follow-up to #1844 (just merged), which migrated the keycloak-plugins image to the repo-linked namespace `ghcr.io/hyperledger-identus/keycloak-plugins`.

#1844 missed **`examples/.nickel/versions.ncl`**, which still pins `identusKeycloak = "0.2.0"`. The Nickel external-keycloak stack (`stack.ncl`) resolves its image tag from this variable:

```
image = "ghcr.io/hyperledger-identus/keycloak-plugins:%{V.identusKeycloak}"
```

The **new namespace only has `0.2.1` published** — `0.2.0` returns HTTP 404 (manifest unknown), the exact failure this migration was fixing. So the example stack would fail to pull.

This bumps the variable `0.2.0 → 0.2.1`.

### Verification
```
ghcr.io/hyperledger-identus/keycloak-plugins:0.2.1  → HTTP 200 (exists)
ghcr.io/hyperledger-identus/keycloak-plugins:0.2.0  → HTTP 404 (does not exist)
```

### Why this wasn't caught by CI
The integration tests use `tests/.../keycloak-oid4vci.yml` (correctly at `0.2.1` since #1844), so CI is green. The Nickel stack is a deployment example, not exercised by CI — hence the gap.

One-line change, no code impact.

Signed-off-by: Pat Losoponkul <patextreme@hotmail.com>