### PR TITLE
ci: bump lint-files.yml workflow pin for editorconfig-checker v3

### DIFF
--- a/.github/workflows/file-hygiene.yml
+++ b/.github/workflows/file-hygiene.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   lint:
-    uses: hyperledger-identus/.github/.github/workflows/lint-files.yml@c52da3503597f26f29f5357a98e25ec63b040929 # main
+    uses: hyperledger-identus/.github/.github/workflows/lint-files.yml@5bdb1e5a46ae66e6bcaa550de3e1e6cc26c0b47d # main

--- a/.github/workflows/file-hygiene.yml
+++ b/.github/workflows/file-hygiene.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   lint:
-    uses: hyperledger-identus/.github/.github/workflows/lint-files.yml@5bdb1e5a46ae66e6bcaa550de3e1e6cc26c0b47d # main
+    uses: hyperledger-identus/.github/.github/workflows/lint-files.yml@b5e934e6d44ea4ff18db76f9eae0405ee4378bd6 # main

--- a/.github/workflows/file-hygiene.yml
+++ b/.github/workflows/file-hygiene.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   lint:
-    uses: hyperledger-identus/.github/.github/workflows/lint-files.yml@f2c9e417fa46f69b015a9cdbaafdfb9e52e4ed60 # main
+    uses: hyperledger-identus/.github/.github/workflows/lint-files.yml@c52da3503597f26f29f5357a98e25ec63b040929 # main


### PR DESCRIPTION
## What
- Bumps the `hyperledger-identus/.github` `lint-files.yml` workflow pin in `file-hygiene.yml` from `f2c9e41` to the merge of hyperledger-identus/.github#8

## Why
The `File Hygiene (editorconfig)` job is currently failing on **all PRs** (e.g. #1876 — [failing run](https://github.com/hyperledger-identus/cloud-agent/actions/runs/33835382571/job/100906713255)) with:

```
##[error]Error: The binary 'ec-linux-amd64*' not found
```

Upstream `editorconfig-checker` v4.0.0 (released 2026-09-03) renamed its release assets, breaking the v2 action. The fix (action v3.0.0 + self-referential workflow fix) is in the shared workflow repo: hyperledger-identus/.github#8 — this PR picks it up here.

✅ Verified: the `File Hygiene (editorconfig)` job passes on this PR.

## ⚠️ Merge order
The `.github` repo requires **linear history**, so .github#8 must be merged via **squash or rebase** — both rewrite the commit SHA. Therefore:

1. Merge **hyperledger-identus/.github#8** (squash or rebase)
2. Update the pinned SHA in this PR to the resulting `main` HEAD commit
3. Then merge this PR